### PR TITLE
Add pool filter, top tokens, token filter, and multi-prices endpoints (v1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-31
+
+### Added
+- **Pool filtering**: `PoolsApi::filterPools()` method for advanced pool filtering by volume, liquidity, transactions, and creation date
+- **Top tokens**: `TokensApi::getTopTokens()` method for discovering top tokens on a network ranked by volume, price, liquidity, or other metrics
+- **Token filtering**: `TokensApi::filterTokens()` method for filtering tokens by volume, liquidity, FDV, transactions, and creation date
+- **Batch prices**: `TokensApi::getMultiPrices()` method for getting prices of up to 10 tokens in a single request
+- Tests for all new endpoints
+
+### Changed
+- Updated SDK VERSION constant to 1.1.0
+
 ## [1.3.0] - 2025-01-27
 
 ### ⚠️ BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ $solanaPools = $client->pools->getNetworkPools('solana', ['limit' => 10]);
 ## Features
 
 - Simple and intuitive PHP interface to all DexPaprika API endpoints
-- Access data from multiple blockchain networks
+- Access data from 33+ blockchain networks
 - Query information about DEXes, liquidity pools, and tokens
 - Get detailed price information, trading volume, and transactions
+- **Filter pools and tokens** by volume, liquidity, FDV, transactions, and creation date
+- **Get top tokens** on any network ranked by volume or other metrics
+- **Batch price lookups** for up to 10 tokens in a single request
 - Search across the entire DexPaprika ecosystem
 - Automatic retry with exponential backoff
 - Response caching with PSR-6 compatible interface
@@ -61,7 +64,7 @@ try {
     $networks = $client->networks->getNetworks();
     
     // Get global statistics
-    $stats = $client->stats->getStats();
+    $stats = $client->utils->getStats();
     
     // Get top pools by network (NEW in v1.3.0)
     $ethereumPools = $client->pools->getNetworkPools('ethereum', ['limit' => 10]);
@@ -167,7 +170,7 @@ $networks = $client->networks->getNetworks();
 
 ```php
 // Get global DEX statistics
-$stats = $client->stats->getStats();
+$stats = $client->utils->getStats();
 ```
 
 ### DEXes
@@ -216,6 +219,50 @@ $tokenPools = $client->tokens->getTokenPools('ethereum', '0xc02aaa39b223fe8d0a0e
     'limit' => 20,
     'reorder' => true  // NEW: Reorder pools so the token becomes the primary token for metrics
 ]);
+```
+
+### Pool Filtering
+
+```php
+// Find high-volume pools on Ethereum
+$filtered = $client->pools->filterPools('ethereum', [
+    'volume24hMin' => 100000,
+    'txns24hMin' => 50,
+    'sortBy' => 'volume_24h',
+    'sortDir' => 'desc',
+    'limit' => 10,
+]);
+echo "Found " . count($filtered['results']) . " pools matching criteria\n";
+```
+
+### Top Tokens & Token Filtering
+
+```php
+// Get top tokens by volume
+$topTokens = $client->tokens->getTopTokens('ethereum', [
+    'orderBy' => 'volume_24h',
+    'limit' => 10,
+]);
+
+// Filter tokens by criteria
+$filtered = $client->tokens->filterTokens('ethereum', [
+    'volume24hMin' => 100000,
+    'fdvMin' => 1000000,
+    'limit' => 10,
+]);
+```
+
+### Batch Token Prices
+
+```php
+// Get prices for multiple tokens in one request (max 10)
+$prices = $client->tokens->getMultiPrices('ethereum', [
+    '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+]);
+foreach ($prices as $p) {
+    echo "{$p['id']}: \${$p['price_usd']}\n";
+}
 ```
 
 ### Search

--- a/src/DexPaprika/Api/PoolsApi.php
+++ b/src/DexPaprika/Api/PoolsApi.php
@@ -251,6 +251,83 @@ class PoolsApi extends BaseApi
     }
 
     /**
+     * Filter pools on a network by volume, liquidity, transactions, and creation date
+     *
+     * @param string $networkId Network ID (e.g., ethereum, solana)
+     * @param array<string, mixed> $options Filter options:
+     *  - int $page: Page number for pagination (1-indexed, default: 1)
+     *  - int $limit: Number of items per page (default: 10, max: 100)
+     *  - string $sortBy: Field to sort by (e.g., 'volume_24h', 'liquidity_usd', 'txns_24h')
+     *  - string $sortDir: Sort direction ('asc' or 'desc', default: 'desc')
+     *  - float $volume24hMin: Minimum 24h volume in USD
+     *  - float $volume24hMax: Maximum 24h volume in USD
+     *  - float $volume7dMin: Minimum 7d volume in USD
+     *  - float $volume7dMax: Maximum 7d volume in USD
+     *  - float $liquidityUsdMin: Minimum liquidity in USD
+     *  - float $liquidityUsdMax: Maximum liquidity in USD
+     *  - int $txns24hMin: Minimum number of transactions in 24h
+     *  - string|int $createdAfter: Only pools created after this time (Unix timestamp)
+     *  - string|int $createdBefore: Only pools created before this time (Unix timestamp)
+     *  - bool $asObject: Whether to return the response as an object (default: false)
+     * @return array<string, mixed>|object Filtered pools with pagination info
+     * @throws ValidationException If parameters are invalid
+     */
+    public function filterPools(string $networkId, array $options = [])
+    {
+        $this->validateNetworkId($networkId);
+
+        if (isset($options['limit']) && ($options['limit'] < 1 || $options['limit'] > 100)) {
+            throw new ValidationException('Limit must be between 1 and 100');
+        }
+
+        $params = [];
+
+        if (isset($options['page'])) {
+            $params['page'] = $options['page'];
+        }
+        if (isset($options['limit'])) {
+            $params['limit'] = $options['limit'];
+        }
+        if (isset($options['sortBy'])) {
+            $params['sort_by'] = $options['sortBy'];
+        }
+        if (isset($options['sortDir'])) {
+            $params['sort_dir'] = $options['sortDir'];
+        }
+        if (isset($options['volume24hMin'])) {
+            $params['volume_24h_min'] = $options['volume24hMin'];
+        }
+        if (isset($options['volume24hMax'])) {
+            $params['volume_24h_max'] = $options['volume24hMax'];
+        }
+        if (isset($options['volume7dMin'])) {
+            $params['volume_7d_min'] = $options['volume7dMin'];
+        }
+        if (isset($options['volume7dMax'])) {
+            $params['volume_7d_max'] = $options['volume7dMax'];
+        }
+        if (isset($options['liquidityUsdMin'])) {
+            $params['liquidity_usd_min'] = $options['liquidityUsdMin'];
+        }
+        if (isset($options['liquidityUsdMax'])) {
+            $params['liquidity_usd_max'] = $options['liquidityUsdMax'];
+        }
+        if (isset($options['txns24hMin'])) {
+            $params['txns_24h_min'] = $options['txns24hMin'];
+        }
+        if (isset($options['createdAfter'])) {
+            $params['created_after'] = $options['createdAfter'];
+        }
+        if (isset($options['createdBefore'])) {
+            $params['created_before'] = $options['createdBefore'];
+        }
+
+        $response = $this->get("/networks/{$networkId}/pools/filter", $params);
+
+        return $this->transformResponse($response, $options['asObject'] ?? false);
+    }
+
+    /**
      * Find a pool by its address on a specific network
      *
      * @param string $networkId Network ID (e.g., ethereum, solana)

--- a/src/DexPaprika/Api/TokensApi.php
+++ b/src/DexPaprika/Api/TokensApi.php
@@ -3,6 +3,7 @@
 namespace DexPaprika\Api;
 
 use DexPaprika\Exception\NotFoundException;
+use DexPaprika\Exception\ValidationException;
 use DexPaprika\Utils\ResponseTransformer;
 
 class TokensApi extends BaseApi
@@ -152,6 +153,163 @@ class TokensApi extends BaseApi
     public function listTokenPairs(string $networkId, string $tokenAddress, array $options = [])
     {
         return $this->getTokenPairs($networkId, $tokenAddress, $options);
+    }
+
+    /**
+     * Get top tokens on a network ranked by volume, price, liquidity, or other metrics
+     *
+     * @param string $networkId Network ID (e.g., ethereum, solana)
+     * @param array<string, mixed> $options Options:
+     *  - int $page: Page number for pagination (1-indexed, default: 1)
+     *  - int $limit: Number of items per page (default: 10, max: 100)
+     *  - string $orderBy: Field to order by (e.g., 'volume_24h', 'price_usd', 'liquidity_usd')
+     *  - string $sort: Sort direction ('asc' or 'desc', default: 'desc')
+     *  - bool $asObject: Whether to return the response as an object (default: false)
+     * @return array<string, mixed>|object Top tokens with pagination info
+     * @throws ValidationException If parameters are invalid
+     */
+    public function getTopTokens(string $networkId, array $options = [])
+    {
+        if (empty($networkId) || trim($networkId) === '') {
+            throw new ValidationException('Network ID is required and cannot be empty');
+        }
+
+        if (isset($options['limit']) && ($options['limit'] < 1 || $options['limit'] > 100)) {
+            throw new ValidationException('Limit must be between 1 and 100');
+        }
+
+        $params = [];
+
+        if (isset($options['page'])) {
+            $params['page'] = $options['page'];
+        }
+        if (isset($options['limit'])) {
+            $params['limit'] = $options['limit'];
+        }
+        if (isset($options['orderBy'])) {
+            $params['order_by'] = $options['orderBy'];
+        }
+        if (isset($options['sort'])) {
+            $params['sort'] = $options['sort'];
+        }
+
+        $response = $this->get("/networks/{$networkId}/tokens/top", $params);
+
+        return $this->transformResponse($response, $options['asObject'] ?? false);
+    }
+
+    /**
+     * Filter tokens on a network by volume, liquidity, FDV, transactions, and creation date
+     *
+     * @param string $networkId Network ID (e.g., ethereum, solana)
+     * @param array<string, mixed> $options Filter options:
+     *  - int $page: Page number for pagination (1-indexed, default: 1)
+     *  - int $limit: Number of items per page (default: 10, max: 100)
+     *  - string $sortBy: Field to sort by (e.g., 'volume_24h', 'liquidity_usd', 'fdv')
+     *  - string $sortDir: Sort direction ('asc' or 'desc', default: 'desc')
+     *  - float $volume24hMin: Minimum 24h volume in USD
+     *  - float $volume24hMax: Maximum 24h volume in USD
+     *  - float $liquidityUsdMin: Minimum liquidity in USD
+     *  - float $fdvMin: Minimum fully diluted valuation in USD
+     *  - float $fdvMax: Maximum fully diluted valuation in USD
+     *  - int $txns24hMin: Minimum number of transactions in 24h
+     *  - string|int $createdAfter: Only tokens created after this time (Unix timestamp)
+     *  - string|int $createdBefore: Only tokens created before this time (Unix timestamp)
+     *  - bool $asObject: Whether to return the response as an object (default: false)
+     * @return array<string, mixed>|object Filtered tokens with pagination info
+     * @throws ValidationException If parameters are invalid
+     */
+    public function filterTokens(string $networkId, array $options = [])
+    {
+        if (empty($networkId) || trim($networkId) === '') {
+            throw new ValidationException('Network ID is required and cannot be empty');
+        }
+
+        if (isset($options['limit']) && ($options['limit'] < 1 || $options['limit'] > 100)) {
+            throw new ValidationException('Limit must be between 1 and 100');
+        }
+
+        $params = [];
+
+        if (isset($options['page'])) {
+            $params['page'] = $options['page'];
+        }
+        if (isset($options['limit'])) {
+            $params['limit'] = $options['limit'];
+        }
+        if (isset($options['sortBy'])) {
+            $params['sort_by'] = $options['sortBy'];
+        }
+        if (isset($options['sortDir'])) {
+            $params['sort_dir'] = $options['sortDir'];
+        }
+        if (isset($options['volume24hMin'])) {
+            $params['volume_24h_min'] = $options['volume24hMin'];
+        }
+        if (isset($options['volume24hMax'])) {
+            $params['volume_24h_max'] = $options['volume24hMax'];
+        }
+        if (isset($options['liquidityUsdMin'])) {
+            $params['liquidity_usd_min'] = $options['liquidityUsdMin'];
+        }
+        if (isset($options['fdvMin'])) {
+            $params['fdv_min'] = $options['fdvMin'];
+        }
+        if (isset($options['fdvMax'])) {
+            $params['fdv_max'] = $options['fdvMax'];
+        }
+        if (isset($options['txns24hMin'])) {
+            $params['txns_24h_min'] = $options['txns24hMin'];
+        }
+        if (isset($options['createdAfter'])) {
+            $params['created_after'] = $options['createdAfter'];
+        }
+        if (isset($options['createdBefore'])) {
+            $params['created_before'] = $options['createdBefore'];
+        }
+
+        $response = $this->get("/networks/{$networkId}/tokens/filter", $params);
+
+        return $this->transformResponse($response, $options['asObject'] ?? false);
+    }
+
+    /**
+     * Get batch prices for multiple tokens on a network
+     *
+     * @param string $networkId Network ID (e.g., ethereum, solana)
+     * @param array<int, string> $tokens Array of token addresses (max 10)
+     * @param array<string, mixed> $options Options:
+     *  - bool $asObject: Whether to return the response as an object (default: false)
+     * @return array<int, array<string, mixed>>|array<int, object> Array of token prices
+     * @throws ValidationException If parameters are invalid
+     */
+    public function getMultiPrices(string $networkId, array $tokens, array $options = [])
+    {
+        if (empty($networkId) || trim($networkId) === '') {
+            throw new ValidationException('Network ID is required and cannot be empty');
+        }
+
+        if (empty($tokens)) {
+            throw new ValidationException('Tokens array is required and must not be empty');
+        }
+
+        if (count($tokens) > 10) {
+            throw new ValidationException('Tokens array must contain at most 10 addresses');
+        }
+
+        $params = [
+            'tokens' => implode(',', $tokens),
+        ];
+
+        $response = $this->get("/networks/{$networkId}/multi/prices", $params);
+
+        if ($options['asObject'] ?? false) {
+            return array_map(function ($item) {
+                return (object) $item;
+            }, $response);
+        }
+
+        return $response;
     }
 
     /**

--- a/src/DexPaprika/Client.php
+++ b/src/DexPaprika/Client.php
@@ -69,7 +69,7 @@ class Client
     /**
      * SDK version
      */
-    public const VERSION = '1.0.0';
+    public const VERSION = '1.1.0';
 
     /**
      * Create a new DexPaprika client

--- a/src/DexPaprika/Client.php
+++ b/src/DexPaprika/Client.php
@@ -6,6 +6,7 @@ use DexPaprika\Api\DexesApi;
 use DexPaprika\Api\NetworksApi;
 use DexPaprika\Api\PoolsApi;
 use DexPaprika\Api\SearchApi;
+use DexPaprika\Api\StatsApi;
 use DexPaprika\Api\TokensApi;
 use DexPaprika\Api\UtilsApi;
 use DexPaprika\Cache\CacheInterface;
@@ -65,6 +66,11 @@ class Client
      * @var UtilsApi
      */
     public UtilsApi $utils;
+
+    /**
+     * @var StatsApi
+     */
+    public StatsApi $stats;
     
     /**
      * SDK version
@@ -107,6 +113,7 @@ class Client
         $this->tokens = new TokensApi($this->httpClient, $this->transformResponses, $this->config);
         $this->search = new SearchApi($this->httpClient, $this->transformResponses, $this->config);
         $this->utils = new UtilsApi($this->httpClient, $this->transformResponses, $this->config);
+        $this->stats = new StatsApi($this->httpClient, $this->transformResponses, $this->config);
     }
 
     /**

--- a/tests/test_new_endpoints.php
+++ b/tests/test_new_endpoints.php
@@ -1,0 +1,144 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use DexPaprika\Client;
+
+$client = new Client();
+$passed = 0;
+$failed = 0;
+
+function test(string $name, callable $fn): void
+{
+    global $passed, $failed;
+    try {
+        $fn();
+        echo "PASS: {$name}\n";
+        $passed++;
+    } catch (\Throwable $e) {
+        echo "FAIL: {$name}: {$e->getMessage()}\n";
+        $failed++;
+    }
+}
+
+// 1. Pool Filter
+test('pools->filterPools - basic', function () use ($client) {
+    $result = $client->pools->filterPools('ethereum', [
+        'volume24hMin' => 100000,
+        'limit' => 5,
+    ]);
+    assert(isset($result['results']), 'Missing results key');
+    assert(count($result['results']) > 0, 'No results');
+    assert(isset($result['page_info']), 'Missing page_info');
+    $pool = $result['results'][0];
+    assert(isset($pool['id']), 'Pool missing id');
+    assert(isset($pool['tokens']), 'Pool missing tokens');
+    echo "   Got " . count($result['results']) . " filtered pools\n";
+});
+
+test('pools->filterPools - multiple params', function () use ($client) {
+    $result = $client->pools->filterPools('ethereum', [
+        'volume24hMin' => 50000,
+        'txns24hMin' => 10,
+        'sortBy' => 'volume_24h',
+        'sortDir' => 'desc',
+        'limit' => 3,
+    ]);
+    assert(isset($result['results']), 'Missing results');
+    echo "   Got " . count($result['results']) . " pools with multi-filter\n";
+});
+
+// 2. Top Tokens
+test('tokens->getTopTokens - basic', function () use ($client) {
+    $result = $client->tokens->getTopTokens('ethereum', ['limit' => 5]);
+    assert(isset($result['tokens']), 'Missing tokens key');
+    assert(count($result['tokens']) > 0, 'No tokens');
+    assert(isset($result['page_info']), 'Missing page_info');
+    $token = $result['tokens'][0];
+    assert(isset($token['address']), 'Token missing address');
+    assert(isset($token['symbol']), 'Token missing symbol');
+    echo "   Top token: {$token['symbol']} at \${$token['price_usd']}\n";
+});
+
+test('tokens->getTopTokens - with sort', function () use ($client) {
+    $result = $client->tokens->getTopTokens('ethereum', [
+        'orderBy' => 'volume_24h',
+        'sort' => 'asc',
+        'limit' => 3,
+    ]);
+    assert(isset($result['tokens']), 'Missing tokens');
+    echo "   Got " . count($result['tokens']) . " tokens (asc)\n";
+});
+
+// 3. Token Filter
+test('tokens->filterTokens - basic', function () use ($client) {
+    $result = $client->tokens->filterTokens('ethereum', [
+        'volume24hMin' => 100000,
+        'limit' => 5,
+    ]);
+    assert(isset($result['results']), 'Missing results key');
+    assert(count($result['results']) > 0, 'No results');
+    assert(isset($result['page_info']), 'Missing page_info');
+    $token = $result['results'][0];
+    assert(isset($token['address']), 'Token missing address');
+    echo "   Got " . count($result['results']) . " filtered tokens\n";
+});
+
+test('tokens->filterTokens - with FDV', function () use ($client) {
+    $result = $client->tokens->filterTokens('ethereum', [
+        'volume24hMin' => 100000,
+        'fdvMin' => 1000000,
+        'limit' => 3,
+    ]);
+    assert(isset($result['results']), 'Missing results');
+    echo "   Got " . count($result['results']) . " tokens with FDV filter\n";
+});
+
+// 4. Multi Prices
+test('tokens->getMultiPrices - two tokens', function () use ($client) {
+    $prices = $client->tokens->getMultiPrices('ethereum', [
+        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+    ]);
+    assert(is_array($prices), 'Expected array');
+    assert(count($prices) === 2, 'Expected 2 prices, got ' . count($prices));
+    echo "   WETH: \${$prices[0]['price_usd']}, USDC: \${$prices[1]['price_usd']}\n";
+});
+
+test('tokens->getMultiPrices - single token', function () use ($client) {
+    $prices = $client->tokens->getMultiPrices('ethereum', [
+        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    ]);
+    assert(count($prices) === 1, 'Expected 1 price');
+});
+
+test('tokens->getMultiPrices - empty validation', function () use ($client) {
+    try {
+        $client->tokens->getMultiPrices('ethereum', []);
+        assert(false, 'Should have thrown');
+    } catch (\DexPaprika\Exception\ValidationException $e) {
+        // Expected
+    }
+});
+
+// Existing endpoint regression checks
+test('existing: networks->getNetworks', function () use ($client) {
+    $networks = $client->networks->getNetworks();
+    assert(count($networks) > 0, 'No networks');
+});
+
+test('existing: pools->getNetworkPools', function () use ($client) {
+    $pools = $client->pools->getNetworkPools('ethereum', ['limit' => 2]);
+    assert(isset($pools['pools']), 'Missing pools');
+});
+
+test('existing: utils->getStats', function () use ($client) {
+    $stats = $client->utils->getStats();
+    assert(isset($stats['chains']), 'Missing chains');
+});
+
+echo "\n" . str_repeat('=', 50) . "\n";
+echo "RESULTS: {$passed} passed, {$failed} failed out of " . ($passed + $failed) . " tests\n";
+echo str_repeat('=', 50) . "\n";
+
+exit($failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- **Pool filtering**: `PoolsApi::filterPools()` for advanced pool filtering by volume, liquidity, transactions, and creation date
- **Top tokens**: `TokensApi::getTopTokens()` for discovering top tokens on a network ranked by volume, price, liquidity
- **Token filtering**: `TokensApi::filterTokens()` for filtering tokens by volume, liquidity, FDV, transactions, and creation date
- **Batch prices**: `TokensApi::getMultiPrices()` for getting prices of up to 10 tokens in a single request
- **Bug fix**: Wired `StatsApi` in `Client.php` so `$client->stats->getStats()` now works (was documented but broken)
- Fixed README references from `$client->stats` to `$client->utils` where StatsApi wasn't available
- 12 tests passing against live API (9 new + 3 regression checks)
- Updated README with new endpoint examples and features list
- Updated CHANGELOG, bumped VERSION constant to 1.1.0

## Test plan
- [x] All 12 tests pass against live `api.dexpaprika.com`
- [x] Both `$client->utils->getStats()` and `$client->stats->getStats()` work
- [ ] Reviewer: run `php tests/test_new_endpoints.php` to verify
- [ ] Reviewer: publish to Packagist after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)