### PR TITLE
feat: advanced pool search (/frontend/v1)

### DIFF
--- a/src/DexPaprika/Api/PoolsApi.php
+++ b/src/DexPaprika/Api/PoolsApi.php
@@ -328,6 +328,140 @@ class PoolsApi extends BaseApi
     }
 
     /**
+     * Advanced pool search across all networks (or a single network).
+     *
+     * Hits the frontend search surface: GET /frontend/v1/pools (global) and
+     * GET /frontend/v1/networks/{network}/pools (per-network). Supports cursor
+     * pagination, sorting, and a rich set of numeric/string filters.
+     *
+     * Pagination here is cursor-based, NOT page-based. Read $response['next_cursor']
+     * from the previous response and pass it back as the 'cursor' option to walk
+     * forward. $response['has_next_page'] tells you whether more results exist.
+     *
+     * Note on sort parameters: this method exposes the canonical 'sortBy' / 'sortDir'
+     * options and translates them to the wire names the backend expects
+     * (sortBy -> order_by, sortDir -> sort). Do not pass order_by/sort directly.
+     *
+     * @param array<string, mixed> $options Search options:
+     *  - string $network: Restrict to a single network (e.g., 'ethereum', 'solana').
+     *                     When omitted, searches across all networks.
+     *  - int $limit: Number of pools per page
+     *  - string $cursor: Cursor for the next page (from a previous response's 'next_cursor')
+     *  - string $sortBy: Field to sort by. One of: volume_usd_24h, volume_usd_7d,
+     *                    volume_usd_30d, liquidity_usd, txns_24h, price_usd,
+     *                    price_change_percentage_24h, created_at (default: volume_usd_24h).
+     *                    Translated to 'order_by' on the wire.
+     *  - string $sortDir: Sort direction, 'asc' or 'desc' (default: 'desc').
+     *                    Translated to 'sort' on the wire.
+     *  - float $volume24hMin / $volume24hMax: 24h volume bounds in USD
+     *  - float $volume7dMin / $volume7dMax: 7d volume bounds in USD
+     *  - float $liquidityUsdMin / $liquidityUsdMax: Liquidity bounds in USD
+     *  - int $txns24hMin: Minimum number of transactions in 24h
+     *  - float $priceUsdMin / $priceUsdMax: Price bounds in USD
+     *  - float $priceChangePercentage24hMin / $priceChangePercentage24hMax: 24h price-change bounds (%)
+     *  - string $dexName: Restrict to a single DEX (e.g., 'uniswap_v3')
+     *  - string|int $createdAfter / $createdBefore: Pool creation time bounds
+     *  - bool $detailed: When true, each token carries fdv plus per-timeframe metric blocks
+     *  - bool $asObject: Whether to return the response as an object (default: false)
+     * @return array<string, mixed>|object Search results: results, has_next_page, next_cursor, query
+     * @throws ValidationException If parameters are invalid
+     */
+    public function advancedSearchPools(array $options = [])
+    {
+        if (isset($options['network'])) {
+            $this->validateNetworkId($options['network']);
+        }
+
+        if (isset($options['limit']) && ($options['limit'] < 1 || $options['limit'] > 100)) {
+            throw new ValidationException('Limit must be between 1 and 100');
+        }
+
+        $params = [];
+
+        if (isset($options['limit'])) {
+            $params['limit'] = $options['limit'];
+        }
+        if (isset($options['cursor'])) {
+            $params['cursor'] = $options['cursor'];
+        }
+        // Canonical sort options translate to the backend wire names:
+        // sortBy -> order_by (field), sortDir -> sort (direction).
+        if (isset($options['sortBy'])) {
+            $params['order_by'] = $options['sortBy'];
+        }
+        if (isset($options['sortDir'])) {
+            $params['sort'] = $options['sortDir'];
+        }
+        if (isset($options['volume24hMin'])) {
+            $params['volume_24h_min'] = $options['volume24hMin'];
+        }
+        if (isset($options['volume24hMax'])) {
+            $params['volume_24h_max'] = $options['volume24hMax'];
+        }
+        if (isset($options['volume7dMin'])) {
+            $params['volume_7d_min'] = $options['volume7dMin'];
+        }
+        if (isset($options['volume7dMax'])) {
+            $params['volume_7d_max'] = $options['volume7dMax'];
+        }
+        if (isset($options['liquidityUsdMin'])) {
+            $params['liquidity_usd_min'] = $options['liquidityUsdMin'];
+        }
+        if (isset($options['liquidityUsdMax'])) {
+            $params['liquidity_usd_max'] = $options['liquidityUsdMax'];
+        }
+        if (isset($options['txns24hMin'])) {
+            $params['txns_24h_min'] = $options['txns24hMin'];
+        }
+        if (isset($options['priceUsdMin'])) {
+            $params['price_usd_min'] = $options['priceUsdMin'];
+        }
+        if (isset($options['priceUsdMax'])) {
+            $params['price_usd_max'] = $options['priceUsdMax'];
+        }
+        if (isset($options['priceChangePercentage24hMin'])) {
+            $params['price_change_percentage_24h_min'] = $options['priceChangePercentage24hMin'];
+        }
+        if (isset($options['priceChangePercentage24hMax'])) {
+            $params['price_change_percentage_24h_max'] = $options['priceChangePercentage24hMax'];
+        }
+        if (isset($options['dexName'])) {
+            $params['dex_name'] = $options['dexName'];
+        }
+        if (isset($options['createdAfter'])) {
+            $params['created_after'] = $options['createdAfter'];
+        }
+        if (isset($options['createdBefore'])) {
+            $params['created_before'] = $options['createdBefore'];
+        }
+        if (isset($options['detailed'])) {
+            // Send a real query string the backend reads as truthy.
+            $params['detailed'] = $options['detailed'] ? 'true' : 'false';
+        }
+
+        if (isset($options['network'])) {
+            $endpoint = "/frontend/v1/networks/{$options['network']}/pools";
+        } else {
+            $endpoint = '/frontend/v1/pools';
+        }
+
+        $response = $this->get($endpoint, $params);
+
+        return $this->transformResponse($response, $options['asObject'] ?? false);
+    }
+
+    /**
+     * Advanced pool search (alias for advancedSearchPools).
+     *
+     * @param array<string, mixed> $options See advancedSearchPools() for the full option list.
+     * @return array<string, mixed>|object Search results: results, has_next_page, next_cursor, query
+     */
+    public function searchPools(array $options = [])
+    {
+        return $this->advancedSearchPools($options);
+    }
+
+    /**
      * Find a pool by its address on a specific network
      *
      * @param string $networkId Network ID (e.g., ethereum, solana)

--- a/tests/DexPaprika/Integration/IntegrationTest.php
+++ b/tests/DexPaprika/Integration/IntegrationTest.php
@@ -96,6 +96,86 @@ class IntegrationTest extends TestCase
         $this->assertLessThanOrEqual(3, count($topPools['pools']));
     }
     
+    public function testAdvancedSearchPoolsGlobal(): void
+    {
+        // Global advanced search across all networks with sorting + a filter.
+        // Canonical sortBy/sortDir must be translated to order_by/sort on the wire.
+        $result = $this->client->pools->advancedSearchPools([
+            'limit' => 3,
+            'sortBy' => 'volume_usd_24h',
+            'sortDir' => 'desc',
+            'priceUsdMin' => 0.5,
+            'dexName' => 'uniswap_v3',
+        ]);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('results', $result);
+        $this->assertArrayHasKey('has_next_page', $result);
+        $this->assertArrayHasKey('next_cursor', $result);
+        $this->assertArrayHasKey('query', $result);
+
+        $this->assertNotEmpty($result['results']);
+        $this->assertLessThanOrEqual(3, count($result['results']));
+
+        // The query echo proves the wire translation: canonical sortBy/sortDir
+        // are sent as order_by/sort, never the raw canonical names.
+        $this->assertSame('volume_usd_24h', $result['query']['order_by']);
+        $this->assertSame('desc', $result['query']['sort']);
+        $this->assertArrayNotHasKey('sort_by', $result['query']);
+        $this->assertArrayNotHasKey('sort_dir', $result['query']);
+
+        // The dex_name filter actually narrows the results.
+        foreach ($result['results'] as $pool) {
+            $this->assertSame('uniswap_v3', $pool['dex_id']);
+        }
+    }
+
+    public function testAdvancedSearchPoolsPerNetwork(): void
+    {
+        // Per-network variant hits /frontend/v1/networks/{network}/pools.
+        $result = $this->client->pools->advancedSearchPools([
+            'network' => 'ethereum',
+            'limit' => 3,
+            'sortBy' => 'volume_usd_24h',
+            'sortDir' => 'desc',
+        ]);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('results', $result);
+        $this->assertNotEmpty($result['results']);
+        $this->assertSame('ethereum', $result['query']['network']);
+
+        // Every returned pool belongs to the requested chain.
+        foreach ($result['results'] as $pool) {
+            $this->assertSame('ethereum', $pool['chain']);
+        }
+    }
+
+    public function testAdvancedSearchPoolsCursorPagination(): void
+    {
+        // Cursor pagination: feed next_cursor back in and the second page must
+        // contain different pools than the first.
+        $page1 = $this->client->pools->advancedSearchPools([
+            'network' => 'ethereum',
+            'limit' => 3,
+        ]);
+
+        $this->assertNotEmpty($page1['results']);
+        $this->assertNotEmpty($page1['next_cursor']);
+
+        $page2 = $this->client->pools->advancedSearchPools([
+            'network' => 'ethereum',
+            'limit' => 3,
+            'cursor' => $page1['next_cursor'],
+        ]);
+
+        $this->assertNotEmpty($page2['results']);
+
+        $page1Ids = array_map(fn($pool) => $pool['id'], $page1['results']);
+        $page2Ids = array_map(fn($pool) => $pool['id'], $page2['results']);
+        $this->assertEmpty(array_intersect($page1Ids, $page2Ids));
+    }
+
     public function testPagination(): void
     {
         $paginator = $this->client->createPaginator(


### PR DESCRIPTION
## What

Adds advanced pool search to `PoolsApi`, backed by the `/frontend/v1` search surface:

- `PoolsApi::advancedSearchPools($options)` — global search across all networks via `GET /frontend/v1/pools`. Pass `network` to scope it to a single chain via `GET /frontend/v1/networks/{network}/pools`.
- `PoolsApi::searchPools($options)` — alias for the same method.

## The wire-name trap

The backend reads `order_by` (sort field) and `sort` (direction), which is the inverse of what you'd guess. I keep those off the public surface. The method takes the canonical `sortBy` / `sortDir` options and translates them to `order_by` / `sort` on the request, the same way `filterPools()` already maps option names to query params. So callers stay on `sortBy`/`sortDir` and never see the inverted names.

## Options

`limit`, `cursor` (cursor pagination — feed back `next_cursor` from the previous response, this endpoint is not page-based), `sortBy`, `sortDir`, the full filter set (`volume24hMin/Max`, `volume7dMin/Max`, `liquidityUsdMin/Max`, `txns24hMin`, `priceUsdMin/Max`, `priceChangePercentage24hMin/Max`, `dexName`, `createdAfter`, `createdBefore`), and `detailed`.

I return the decoded response untouched (`results`, `has_next_page`, `next_cursor`, `query`), matching how the rest of this SDK passes responses through rather than forcing them into typed models. Nothing in the response is hard-required, so a field the API drops won't break a caller.

## Tests

Added three live integration tests in `IntegrationTest.php` (run under `DEXPAPRIKA_RUN_INTEGRATION_TESTS=1`, gated by the `integration` group):

- global search — asserts the `data` shape, non-empty results, that the `sortBy`->`order_by` / `sortDir`->`sort` translation lands in the `query` echo, and that the `dexName` filter actually narrows results to `uniswap_v3`
- per-network search — asserts every returned pool is on the requested chain
- cursor pagination — feeds `next_cursor` back in and checks page 2 has no overlap with page 1

## Verification

```
# new integration tests (live)
$ DEXPAPRIKA_RUN_INTEGRATION_TESTS=1 phpunit --group integration --filter AdvancedSearch
OK (3 tests, 26 assertions)

# full unit suite still green
$ phpunit --testsuite "Unit Tests"
OK (89 tests, 296 assertions)
```

The 5 other integration tests that fail (`testGetTopPools`, `testPagination`, `testObjectTransformation`, etc.) are pre-existing failures on the base branch — the deprecated 410 `/pools` endpoint and a missing `Client::setTransformResponses()` — unrelated to this change.