### PR TITLE
Add CI (PHP matrix + offline PHPUnit suite)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Least privilege: CI only reads the repo and runs the test suite.
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (php ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3', '8.4']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      # The PHPUnit suite is fully offline (Guzzle MockHandler) — no live API
+      # calls, so CI does not depend on api.dexpaprika.com being up or stable.
+      - name: Run tests
+        run: composer test


### PR DESCRIPTION
Adds GitHub Actions CI (repo had none): PHP 8.1-8.4 matrix, composer validate + install + `composer test` (PHPUnit). The suite is fully offline (Guzzle MockHandler) so CI makes no live api.dexpaprika.com calls and stays green regardless of upstream API changes. Verified locally: 89 tests, 296 assertions pass. GITHUB_TOKEN pinned to contents: read. Part of coinpaprika/devrel#42.