### PR TITLE
Fix CI push trigger to match default branch (sdkv1.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [sdkv1.0.0, main]
   pull_request:
 
 # Least privilege: CI only reads the repo and runs the test suite.


### PR DESCRIPTION
Follow-up to the CI PR (#6). The push trigger watched `main`, but this repo's default branch is `sdkv1.0.0` — so CI ran on PRs but never on pushes/merges to the default branch. Added `sdkv1.0.0` to the push `branches` (kept `main` for future-proofing). PR-level CI was already working; this restores the green/red signal on the default branch too.