### PR TITLE
Fix 410s: migrate pool/token list+filter methods to /search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-06-30
+
+### Changed
+- **Unified search endpoints**: `PoolsApi::getNetworkPools()` and `PoolsApi::filterPools()` now call `/networks/{network}/pools/search`; `TokensApi::getTopTokens()` and `TokensApi::filterTokens()` now call `/networks/{network}/tokens/search`. The previous list/filter/top endpoints return `410 Gone`.
+- **Cursor pagination**: these four methods now return `results`, `has_next_page` and `next_cursor` instead of `pools`/`tokens` plus `page_info`. The `page` option is still accepted but ignored; pass `cursor` to page through results.
+- **Filter methods** now send `order_by` + `sort` (previously `sort_by` + `sort_dir`).
+- Public method signatures are unchanged. Legacy sort values (e.g. `volume_usd`, `transactions`, `fdv`, `price_usd`) and legacy filter parameter names (e.g. `volume24hMin` -> `volume_usd_24h_min`) are mapped to the canonical search names automatically so requests do not return `400`.
+- `Paginator` now understands cursor-paginated responses (`has_next_page`/`next_cursor`) in addition to offset-based `page_info`.
+- Updated SDK VERSION constant to 1.2.0.
+
+### Added
+- `DexPaprika\Utils\SearchParams` helper with shared, pure sort-field and filter-parameter mappers used by pools and tokens.
+
 ## [1.1.0] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,6 +18,31 @@ $solanaPools = $client->pools->getNetworkPools('solana', ['limit' => 10]);
 
 **See the [Migration Guide](examples/migration_guide.php) and [CHANGELOG](CHANGELOG.md) for complete details.**
 
+## Unified search endpoints (v1.2.0)
+
+`getNetworkPools()`, `filterPools()`, `getTopTokens()` and `filterTokens()` now call the
+unified `pools/search` and `tokens/search` endpoints (the previous list/filter/top
+endpoints return `410 Gone`). The public method signatures are unchanged: legacy sort
+values (for example `volume_usd`, `fdv`) and legacy filter parameter names (for example
+`volume24hMin`) are mapped to the canonical search names automatically.
+
+These endpoints are cursor-paginated, so the response shape is:
+
+```php
+$page = $client->pools->getNetworkPools('ethereum', ['limit' => 20]);
+$page['results'];        // array of items
+$page['has_next_page'];  // bool
+$page['next_cursor'];    // string|null
+
+// Fetch the next page with the cursor
+$next = $client->pools->getNetworkPools('ethereum', [
+    'limit' => 20,
+    'cursor' => $page['next_cursor'],
+]);
+```
+
+The `page` option is still accepted for backward compatibility but is ignored.
+
 ## Features
 
 - Simple and intuitive PHP interface to all DexPaprika API endpoints

--- a/src/DexPaprika/Api/PoolsApi.php
+++ b/src/DexPaprika/Api/PoolsApi.php
@@ -6,6 +6,7 @@ use DexPaprika\Exception\NotFoundException;
 use DexPaprika\Exception\DeprecationException;
 use DexPaprika\Exception\ValidationException;
 use DexPaprika\Utils\ResponseTransformer;
+use DexPaprika\Utils\SearchParams;
 
 class PoolsApi extends BaseApi
 {
@@ -64,12 +65,20 @@ class PoolsApi extends BaseApi
     /**
      * Get a list of top liquidity pools on a specific network
      *
+     * Backed by the unified /networks/{network}/pools/search endpoint, which is
+     * cursor-paginated. The response is shaped as:
+     * {@code results[], has_next_page, next_cursor, query}. Each pool exposes
+     * id (pool address), chain, dex_id, dex_name, fee, created_at,
+     * volume_usd_24h/7d/30d, liquidity_usd, transactions_24h, price_usd,
+     * price_change_percentage_5m/1h/24h and tokens[].
+     *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param array<string, mixed> $options Additional options:
-     *  - int $page: Page number for pagination (default: 0)
+     *  - int $page: Accepted for backward compatibility but ignored (the endpoint is cursor-based)
+     *  - string $cursor: Opaque cursor from a previous response's next_cursor
      *  - int $limit: Number of items per page (default: 10, max: 100)
-     *  - string $orderBy: Field to order by (default: 'volume_usd')
-     *  - string $sort: Sort order (default: 'desc')
+     *  - string $orderBy: Field to order by (legacy values are mapped, default: 'volume_usd_24h')
+     *  - string $sort: Sort direction ('asc' or 'desc', default: 'desc')
      *  - bool $asObject: Whether to return the response as an object (default: false)
      * @return array<string, mixed>|object List of pools on the specified network
      * @throws ValidationException If network ID is invalid or parameters are out of range
@@ -78,7 +87,7 @@ class PoolsApi extends BaseApi
     {
         // Validate required network parameter
         $this->validateNetworkId($networkId);
-        
+
         // Validate limit parameter
         if (isset($options['limit']) && ($options['limit'] < 1 || $options['limit'] > 100)) {
             throw new ValidationException('Limit must be between 1 and 100');
@@ -86,24 +95,24 @@ class PoolsApi extends BaseApi
 
         $params = [];
 
-        if (isset($options['page'])) {
-            $params['page'] = $options['page'];
-        }
-
         if (isset($options['limit'])) {
             $params['limit'] = $options['limit'];
         }
 
         if (isset($options['orderBy'])) {
-            $params['order_by'] = $options['orderBy'];
+            $params['order_by'] = SearchParams::mapPoolSortField($options['orderBy']);
         }
 
         if (isset($options['sort'])) {
             $params['sort'] = $options['sort'];
         }
 
-        $response = $this->get("/networks/{$networkId}/pools", $params);
-        
+        if (isset($options['cursor'])) {
+            $params['cursor'] = $options['cursor'];
+        }
+
+        $response = $this->get("/networks/{$networkId}/pools/search", $params);
+
         return $this->transformResponse($response, $options['asObject'] ?? false);
     }
 
@@ -253,11 +262,17 @@ class PoolsApi extends BaseApi
     /**
      * Filter pools on a network by volume, liquidity, transactions, and creation date
      *
+     * Backed by the unified /networks/{network}/pools/search endpoint, which is
+     * cursor-paginated and returns {@code results[], has_next_page, next_cursor, query}.
+     * Legacy sort-field values and legacy filter parameter names are mapped to the
+     * canonical search names so requests do not 400.
+     *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param array<string, mixed> $options Filter options:
-     *  - int $page: Page number for pagination (1-indexed, default: 1)
+     *  - int $page: Accepted for backward compatibility but ignored (the endpoint is cursor-based)
+     *  - string $cursor: Opaque cursor from a previous response's next_cursor
      *  - int $limit: Number of items per page (default: 10, max: 100)
-     *  - string $sortBy: Field to sort by (e.g., 'volume_24h', 'liquidity_usd', 'txns_24h')
+     *  - string $sortBy: Field to sort by (legacy values mapped, e.g. 'volume_24h' -> 'volume_usd_24h')
      *  - string $sortDir: Sort direction ('asc' or 'desc', default: 'desc')
      *  - float $volume24hMin: Minimum 24h volume in USD
      *  - float $volume24hMax: Maximum 24h volume in USD
@@ -269,7 +284,7 @@ class PoolsApi extends BaseApi
      *  - string|int $createdAfter: Only pools created after this time (Unix timestamp)
      *  - string|int $createdBefore: Only pools created before this time (Unix timestamp)
      *  - bool $asObject: Whether to return the response as an object (default: false)
-     * @return array<string, mixed>|object Filtered pools with pagination info
+     * @return array<string, mixed>|object Filtered pools (results[] + has_next_page + next_cursor)
      * @throws ValidationException If parameters are invalid
      */
     public function filterPools(string $networkId, array $options = [])
@@ -282,17 +297,17 @@ class PoolsApi extends BaseApi
 
         $params = [];
 
-        if (isset($options['page'])) {
-            $params['page'] = $options['page'];
-        }
         if (isset($options['limit'])) {
             $params['limit'] = $options['limit'];
         }
+        if (isset($options['cursor'])) {
+            $params['cursor'] = $options['cursor'];
+        }
         if (isset($options['sortBy'])) {
-            $params['sort_by'] = $options['sortBy'];
+            $params['order_by'] = SearchParams::mapPoolSortField($options['sortBy']);
         }
         if (isset($options['sortDir'])) {
-            $params['sort_dir'] = $options['sortDir'];
+            $params['sort'] = $options['sortDir'];
         }
         if (isset($options['volume24hMin'])) {
             $params['volume_24h_min'] = $options['volume24hMin'];
@@ -322,7 +337,10 @@ class PoolsApi extends BaseApi
             $params['created_before'] = $options['createdBefore'];
         }
 
-        $response = $this->get("/networks/{$networkId}/pools/filter", $params);
+        // Normalise legacy filter parameter names to their canonical search names.
+        $params = SearchParams::mapPoolFilterParams($params);
+
+        $response = $this->get("/networks/{$networkId}/pools/search", $params);
 
         return $this->transformResponse($response, $options['asObject'] ?? false);
     }
@@ -388,13 +406,17 @@ class PoolsApi extends BaseApi
     /**
      * Fetch all pools from a network page by page using a callback function
      *
+     * Walks the cursor-paginated /networks/{network}/pools/search endpoint,
+     * threading next_cursor between requests and stopping when has_next_page is false.
+     *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param callable $callback Function to call for each page of pools: function(array|object $pools, int $page): bool
      *                          Return false from the callback to stop pagination
      * @param array<string, mixed> $options Additional options:
+     *  - string $cursor: Opaque cursor to start from (optional)
      *  - int $limit: Number of items per page (default: 10, max: 100)
-     *  - string $orderBy: Field to order by (default: 'volume_usd')
-     *  - string $sort: Sort order (default: 'desc')
+     *  - string $orderBy: Field to order by (legacy values mapped, default: 'volume_usd_24h')
+     *  - string $sort: Sort direction ('asc' or 'desc', default: 'desc')
      *  - int $maxPages: Maximum number of pages to fetch (default: 10, use 0 for unlimited)
      *  - bool $asObject: Whether to return the response as an object (default: false)
      * @return int Total number of pages fetched
@@ -403,64 +425,51 @@ class PoolsApi extends BaseApi
     {
         $page = 0;
         $totalPages = 0;
-        $limit = $options['limit'] ?? 10;
         $maxPages = $options['maxPages'] ?? 10;
-        
-        // Set asObject and remove from options to pass to API
+
+        // Set asObject and remove iterator-only keys before passing to the API
         $asObject = $options['asObject'] ?? false;
         $apiOptions = $options;
-        unset($apiOptions['maxPages'], $apiOptions['asObject']);
-        $apiOptions['page'] = $page;
-        
+        unset($apiOptions['maxPages'], $apiOptions['asObject'], $apiOptions['cursor']);
+
+        $cursor = $options['cursor'] ?? null;
+
         do {
-            $response = $this->getNetworkPools($networkId, array_merge($apiOptions, ['asObject' => $asObject]));
-            
+            $callOptions = array_merge($apiOptions, ['asObject' => $asObject]);
+            if ($cursor !== null && $cursor !== '') {
+                $callOptions['cursor'] = $cursor;
+            }
+
+            $response = $this->getNetworkPools($networkId, $callOptions);
+
             $continueProcessing = $callback($response, $page);
             $totalPages++;
             $page++;
-            
-            // Update the page number for the next request
-            $apiOptions['page'] = $page;
-            
+
             // Check if we should continue processing
             if ($continueProcessing === false) {
                 break;
             }
-            
+
             // Check if we've reached the maximum number of pages
             if ($maxPages > 0 && $page >= $maxPages) {
                 break;
             }
-            
-            // Check if we've reached the end of available pools
+
+            // Determine the next cursor from the search response shape
             if ($asObject) {
-                if (!isset($response->pools) || count($response->pools) < $limit) {
-                    break;
-                }
-                
-                // Check if we've reached the last page based on page_info
-                if (isset($response->page_info) && 
-                    isset($response->page_info->page) && 
-                    isset($response->page_info->total_pages) && 
-                    $response->page_info->page + 1 >= $response->page_info->total_pages) {
-                    break;
-                }
+                $hasNext = $response->has_next_page ?? false;
+                $cursor = $response->next_cursor ?? null;
             } else {
-                if (!isset($response['pools']) || count($response['pools']) < $limit) {
-                    break;
-                }
-                
-                // Check if we've reached the last page based on page_info
-                if (isset($response['page_info']) && 
-                    isset($response['page_info']['page']) && 
-                    isset($response['page_info']['total_pages']) && 
-                    $response['page_info']['page'] + 1 >= $response['page_info']['total_pages']) {
-                    break;
-                }
+                $hasNext = $response['has_next_page'] ?? false;
+                $cursor = $response['next_cursor'] ?? null;
             }
-            
+
+            if (!$hasNext || $cursor === null || $cursor === '') {
+                break;
+            }
         } while (true);
-        
+
         return $totalPages;
     }
 

--- a/src/DexPaprika/Api/TokensApi.php
+++ b/src/DexPaprika/Api/TokensApi.php
@@ -5,6 +5,7 @@ namespace DexPaprika\Api;
 use DexPaprika\Exception\NotFoundException;
 use DexPaprika\Exception\ValidationException;
 use DexPaprika\Utils\ResponseTransformer;
+use DexPaprika\Utils\SearchParams;
 
 class TokensApi extends BaseApi
 {
@@ -156,16 +157,23 @@ class TokensApi extends BaseApi
     }
 
     /**
-     * Get top tokens on a network ranked by volume, price, liquidity, or other metrics
+     * Get top tokens on a network ranked by volume, liquidity, or other metrics
+     *
+     * Backed by the unified /networks/{network}/tokens/search endpoint, which is
+     * cursor-paginated. The response is shaped as:
+     * {@code results[], has_next_page, next_cursor, query}. Each token exposes
+     * address, chain, created_at, price_usd, volume_usd_24h/7d/30d, liquidity_usd,
+     * fdv_usd, txns_24h and price_change_percentage_24h (a flat shape, no name/symbol).
      *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param array<string, mixed> $options Options:
-     *  - int $page: Page number for pagination (1-indexed, default: 1)
+     *  - int $page: Accepted for backward compatibility but ignored (the endpoint is cursor-based)
+     *  - string $cursor: Opaque cursor from a previous response's next_cursor
      *  - int $limit: Number of items per page (default: 10, max: 100)
-     *  - string $orderBy: Field to order by (e.g., 'volume_24h', 'price_usd', 'liquidity_usd')
+     *  - string $orderBy: Field to order by (legacy values mapped, default: 'volume_usd_24h')
      *  - string $sort: Sort direction ('asc' or 'desc', default: 'desc')
      *  - bool $asObject: Whether to return the response as an object (default: false)
-     * @return array<string, mixed>|object Top tokens with pagination info
+     * @return array<string, mixed>|object Top tokens (results[] + has_next_page + next_cursor)
      * @throws ValidationException If parameters are invalid
      */
     public function getTopTokens(string $networkId, array $options = [])
@@ -180,20 +188,20 @@ class TokensApi extends BaseApi
 
         $params = [];
 
-        if (isset($options['page'])) {
-            $params['page'] = $options['page'];
-        }
         if (isset($options['limit'])) {
             $params['limit'] = $options['limit'];
         }
         if (isset($options['orderBy'])) {
-            $params['order_by'] = $options['orderBy'];
+            $params['order_by'] = SearchParams::mapTokenSortField($options['orderBy']);
         }
         if (isset($options['sort'])) {
             $params['sort'] = $options['sort'];
         }
+        if (isset($options['cursor'])) {
+            $params['cursor'] = $options['cursor'];
+        }
 
-        $response = $this->get("/networks/{$networkId}/tokens/top", $params);
+        $response = $this->get("/networks/{$networkId}/tokens/search", $params);
 
         return $this->transformResponse($response, $options['asObject'] ?? false);
     }
@@ -201,11 +209,17 @@ class TokensApi extends BaseApi
     /**
      * Filter tokens on a network by volume, liquidity, FDV, transactions, and creation date
      *
+     * Backed by the unified /networks/{network}/tokens/search endpoint, which is
+     * cursor-paginated and returns {@code results[], has_next_page, next_cursor, query}.
+     * Legacy sort-field values and legacy filter parameter names are mapped to the
+     * canonical search names so requests do not 400.
+     *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param array<string, mixed> $options Filter options:
-     *  - int $page: Page number for pagination (1-indexed, default: 1)
+     *  - int $page: Accepted for backward compatibility but ignored (the endpoint is cursor-based)
+     *  - string $cursor: Opaque cursor from a previous response's next_cursor
      *  - int $limit: Number of items per page (default: 10, max: 100)
-     *  - string $sortBy: Field to sort by (e.g., 'volume_24h', 'liquidity_usd', 'fdv')
+     *  - string $sortBy: Field to sort by (legacy values mapped, e.g. 'fdv' -> 'fdv_usd')
      *  - string $sortDir: Sort direction ('asc' or 'desc', default: 'desc')
      *  - float $volume24hMin: Minimum 24h volume in USD
      *  - float $volume24hMax: Maximum 24h volume in USD
@@ -216,7 +230,7 @@ class TokensApi extends BaseApi
      *  - string|int $createdAfter: Only tokens created after this time (Unix timestamp)
      *  - string|int $createdBefore: Only tokens created before this time (Unix timestamp)
      *  - bool $asObject: Whether to return the response as an object (default: false)
-     * @return array<string, mixed>|object Filtered tokens with pagination info
+     * @return array<string, mixed>|object Filtered tokens (results[] + has_next_page + next_cursor)
      * @throws ValidationException If parameters are invalid
      */
     public function filterTokens(string $networkId, array $options = [])
@@ -231,17 +245,17 @@ class TokensApi extends BaseApi
 
         $params = [];
 
-        if (isset($options['page'])) {
-            $params['page'] = $options['page'];
-        }
         if (isset($options['limit'])) {
             $params['limit'] = $options['limit'];
         }
+        if (isset($options['cursor'])) {
+            $params['cursor'] = $options['cursor'];
+        }
         if (isset($options['sortBy'])) {
-            $params['sort_by'] = $options['sortBy'];
+            $params['order_by'] = SearchParams::mapTokenSortField($options['sortBy']);
         }
         if (isset($options['sortDir'])) {
-            $params['sort_dir'] = $options['sortDir'];
+            $params['sort'] = $options['sortDir'];
         }
         if (isset($options['volume24hMin'])) {
             $params['volume_24h_min'] = $options['volume24hMin'];
@@ -268,7 +282,10 @@ class TokensApi extends BaseApi
             $params['created_before'] = $options['createdBefore'];
         }
 
-        $response = $this->get("/networks/{$networkId}/tokens/filter", $params);
+        // Normalise legacy filter parameter names to their canonical search names.
+        $params = SearchParams::mapTokenFilterParams($params);
+
+        $response = $this->get("/networks/{$networkId}/tokens/search", $params);
 
         return $this->transformResponse($response, $options['asObject'] ?? false);
     }

--- a/src/DexPaprika/Client.php
+++ b/src/DexPaprika/Client.php
@@ -75,7 +75,7 @@ class Client
     /**
      * SDK version
      */
-    public const VERSION = '1.1.0';
+    public const VERSION = '1.2.0';
 
     /**
      * Create a new DexPaprika client

--- a/src/DexPaprika/Utils/Paginator.php
+++ b/src/DexPaprika/Utils/Paginator.php
@@ -35,6 +35,11 @@ class Paginator
      * @var array<string, mixed>|null The current page result
      */
     private ?array $currentResult = null;
+
+    /**
+     * @var string|null The cursor for the next page (cursor-paginated endpoints)
+     */
+    private ?string $nextCursor = null;
     
     /**
      * Create a new paginator
@@ -68,8 +73,12 @@ class Paginator
      */
     public function getNextPage(): array
     {
-        // Add page parameter to method params
+        // Add page parameter to method params (ignored by cursor-based endpoints)
+        // and thread the cursor through for cursor-paginated search endpoints.
         $params = array_merge($this->params, ['page' => $this->currentPage]);
+        if ($this->nextCursor !== null && $this->nextCursor !== '') {
+            $params['cursor'] = $this->nextCursor;
+        }
         
         // Build arguments array from parameters (handling positional parameters)
         $args = [];
@@ -106,11 +115,16 @@ class Paginator
         $this->currentPage++;
         $pageInfo = $result['page_info'] ?? null;
         if ($pageInfo) {
+            // Legacy offset-paginated endpoints (e.g. dexes pools, transactions)
             $this->hasNext = $this->currentPage < ($pageInfo['total_pages'] ?? 0);
+        } elseif (array_key_exists('has_next_page', $result)) {
+            // Cursor-paginated search endpoints (pools/search, tokens/search)
+            $this->hasNext = (bool) ($result['has_next_page'] ?? false);
+            $this->nextCursor = $result['next_cursor'] ?? null;
         } else {
             $this->hasNext = false;
         }
-        
+
         return $result;
     }
     
@@ -146,7 +160,7 @@ class Paginator
             
             // Extract items from the result based on common patterns
             $items = null;
-            foreach (['pools', 'tokens', 'dexes', 'transactions'] as $key) {
+            foreach (['results', 'pools', 'tokens', 'dexes', 'transactions'] as $key) {
                 if (isset($result[$key]) && is_array($result[$key])) {
                     $items = $result[$key];
                     break;

--- a/src/DexPaprika/Utils/SearchParams.php
+++ b/src/DexPaprika/Utils/SearchParams.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace DexPaprika\Utils;
+
+/**
+ * Pure helpers that normalise the legacy parameter names and values the SDK
+ * accepts onto the canonical query parameters required by the unified search
+ * endpoints (/networks/{network}/pools/search and /networks/{network}/tokens/search).
+ *
+ * The search endpoints return HTTP 400 on legacy sort-field values and legacy
+ * filter parameter names, so anything the SDK keeps accepting for backward
+ * compatibility has to be mapped before it reaches the wire. Pools and tokens
+ * share these helpers; only the lookup tables differ.
+ */
+class SearchParams
+{
+    /**
+     * Default order_by used when a sort field is missing or unrecognised.
+     */
+    public const DEFAULT_SORT_FIELD = 'volume_usd_24h';
+
+    /**
+     * Legacy to canonical sort fields for pools/search.
+     *
+     * @var array<string, string>
+     */
+    private const POOL_SORT_ALIASES = [
+        'volume_usd' => 'volume_usd_24h',
+        'transactions' => 'txns_24h',
+        'last_price_change_usd_24h' => 'price_change_percentage_24h',
+        'volume_24h' => 'volume_usd_24h',
+        'volume_7d' => 'volume_usd_7d',
+        'volume_30d' => 'volume_usd_30d',
+        'liquidity' => 'liquidity_usd',
+    ];
+
+    /**
+     * Canonical sort fields accepted as-is by pools/search.
+     *
+     * @var array<int, string>
+     */
+    private const POOL_SORT_CANONICAL = [
+        'volume_usd_24h',
+        'volume_usd_7d',
+        'volume_usd_30d',
+        'liquidity_usd',
+        'txns_24h',
+        'created_at',
+        'price_usd',
+        'price_change_percentage_24h',
+    ];
+
+    /**
+     * Legacy to canonical sort fields for tokens/search.
+     *
+     * @var array<string, string>
+     */
+    private const TOKEN_SORT_ALIASES = [
+        'volume_24h' => 'volume_usd_24h',
+        'txns' => 'txns_24h',
+        'price_change' => 'price_change_percentage_24h',
+        'fdv' => 'fdv_usd',
+        'volume_7d' => 'volume_usd_7d',
+        'volume_30d' => 'volume_usd_30d',
+        // tokens/search returns 400 when ordering by price, so fall back to volume.
+        'price_usd' => 'volume_usd_24h',
+    ];
+
+    /**
+     * Canonical sort fields accepted as-is by tokens/search.
+     *
+     * @var array<int, string>
+     */
+    private const TOKEN_SORT_CANONICAL = [
+        'volume_usd_24h',
+        'volume_usd_7d',
+        'volume_usd_30d',
+        'liquidity_usd',
+        'txns_24h',
+        'fdv_usd',
+        'created_at',
+        'price_change_percentage_24h',
+    ];
+
+    /**
+     * Legacy to canonical filter query parameter names for pools/search.
+     *
+     * @var array<string, string>
+     */
+    private const POOL_FILTER_RENAME = [
+        'volume_24h_min' => 'volume_usd_24h_min',
+        'volume_24h_max' => 'volume_usd_24h_max',
+        'volume_7d_min' => 'volume_usd_7d_min',
+        'volume_7d_max' => 'volume_usd_7d_max',
+    ];
+
+    /**
+     * Legacy to canonical filter query parameter names for tokens/search.
+     *
+     * @var array<string, string>
+     */
+    private const TOKEN_FILTER_RENAME = [
+        'volume_24h_min' => 'volume_usd_24h_min',
+        'volume_24h_max' => 'volume_usd_24h_max',
+    ];
+
+    /**
+     * Map a pool sort field (legacy or canonical) to the canonical order_by value.
+     *
+     * @param string|null $value
+     */
+    public static function mapPoolSortField(?string $value): string
+    {
+        return self::mapSortField($value, self::POOL_SORT_ALIASES, self::POOL_SORT_CANONICAL);
+    }
+
+    /**
+     * Map a token sort field (legacy or canonical) to the canonical order_by value.
+     *
+     * @param string|null $value
+     */
+    public static function mapTokenSortField(?string $value): string
+    {
+        return self::mapSortField($value, self::TOKEN_SORT_ALIASES, self::TOKEN_SORT_CANONICAL);
+    }
+
+    /**
+     * Rename legacy pool filter query parameters to their canonical search names.
+     *
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    public static function mapPoolFilterParams(array $params): array
+    {
+        return self::renameKeys($params, self::POOL_FILTER_RENAME);
+    }
+
+    /**
+     * Rename legacy token filter query parameters to their canonical search names.
+     *
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    public static function mapTokenFilterParams(array $params): array
+    {
+        return self::renameKeys($params, self::TOKEN_FILTER_RENAME);
+    }
+
+    /**
+     * Resolve a sort field against a lookup table, falling back to the default.
+     *
+     * @param string|null $value
+     * @param array<string, string> $aliases
+     * @param array<int, string> $canonical
+     */
+    private static function mapSortField(?string $value, array $aliases, array $canonical): string
+    {
+        if ($value === null || $value === '') {
+            return self::DEFAULT_SORT_FIELD;
+        }
+
+        if (in_array($value, $canonical, true)) {
+            return $value;
+        }
+
+        return $aliases[$value] ?? self::DEFAULT_SORT_FIELD;
+    }
+
+    /**
+     * Rename array keys according to a map, passing unknown keys through unchanged.
+     *
+     * @param array<string, mixed> $params
+     * @param array<string, string> $rename
+     * @return array<string, mixed>
+     */
+    private static function renameKeys(array $params, array $rename): array
+    {
+        $out = [];
+
+        foreach ($params as $key => $value) {
+            $out[$rename[$key] ?? $key] = $value;
+        }
+
+        return $out;
+    }
+}

--- a/tests/DexPaprika/PoolsApiTest.php
+++ b/tests/DexPaprika/PoolsApiTest.php
@@ -80,18 +80,14 @@ class PoolsApiTest extends TestCase
 
     public function testGetNetworkPools(): void
     {
-        // Mock the API response for getNetworkPools
+        // Mock the API response for getNetworkPools (cursor-paginated search shape)
         $expectedResponse = [
-            'pools' => [
-                ['id' => 'eth_wbtc', 'name' => 'ETH/WBTC'],
-                ['id' => 'eth_usdc', 'name' => 'ETH/USDC']
+            'results' => [
+                ['id' => '0xpool1', 'tokens' => [['id' => 'eth', 'name' => 'Ether', 'symbol' => 'ETH']]],
+                ['id' => '0xpool2', 'tokens' => [['id' => 'usdc', 'name' => 'USD Coin', 'symbol' => 'USDC']]]
             ],
-            'page_info' => [
-                'page' => 0,
-                'total_pages' => 5,
-                'items_on_page' => 2,
-                'total_items' => 10
-            ]
+            'has_next_page' => true,
+            'next_cursor' => 'cursor_abc',
         ];
 
         // Create a mock for the PoolsApi that only mocks the get method
@@ -100,19 +96,18 @@ class PoolsApiTest extends TestCase
             ->onlyMethods(['get'])
             ->getMock();
 
-        // Set up expectations for the mocked get method
+        // The page option must be dropped (cursor-based) and the search endpoint used
         $mockApi->expects($this->any())
             ->method('get')
             ->with(
-                $this->equalTo('/networks/ethereum/pools'),
+                $this->equalTo('/networks/ethereum/pools/search'),
                 $this->equalTo([
-                    'page' => 0,
                     'limit' => 10
                 ])
             )
             ->willReturn($expectedResponse);
 
-        // Call the method with test parameters
+        // Call the method with test parameters (page is accepted but ignored)
         $result = $mockApi->getNetworkPools('ethereum', [
             'page' => 0,
             'limit' => 10
@@ -130,8 +125,69 @@ class PoolsApiTest extends TestCase
 
         // Verify transformation to object
         $this->assertIsObject($result);
-        $this->assertIsArray($result->pools);
-        $this->assertEquals(2, count($result->pools));
+        $this->assertIsArray($result->results);
+        $this->assertEquals(2, count($result->results));
+        $this->assertEquals('0xpool1', $result->results[0]->id);
+    }
+
+    public function testGetNetworkPoolsMapsLegacySortField(): void
+    {
+        // A legacy sort field value must be mapped to its canonical search name
+        $mockApi = $this->getMockBuilder(PoolsApi::class)
+            ->setConstructorArgs([$this->createMockClient([])])
+            ->onlyMethods(['get'])
+            ->getMock();
+
+        $mockApi->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/networks/ethereum/pools/search'),
+                $this->equalTo([
+                    'limit' => 5,
+                    'order_by' => 'volume_usd_24h',
+                    'sort' => 'desc',
+                ])
+            )
+            ->willReturn(['results' => [], 'has_next_page' => false, 'next_cursor' => null]);
+
+        $mockApi->getNetworkPools('ethereum', [
+            'limit' => 5,
+            'orderBy' => 'volume_usd', // legacy -> volume_usd_24h
+            'sort' => 'desc',
+        ]);
+    }
+
+    public function testFilterPoolsUsesSearchEndpointAndMapsParams(): void
+    {
+        // filterPools must hit /pools/search, send order_by + sort (not sort_by/sort_dir),
+        // drop page, and rename legacy filter params to canonical names.
+        $mockApi = $this->getMockBuilder(PoolsApi::class)
+            ->setConstructorArgs([$this->createMockClient([])])
+            ->onlyMethods(['get'])
+            ->getMock();
+
+        $mockApi->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/networks/ethereum/pools/search'),
+                $this->equalTo([
+                    'limit' => 3,
+                    'order_by' => 'volume_usd_24h',
+                    'sort' => 'desc',
+                    'volume_usd_24h_min' => 50000,
+                    'txns_24h_min' => 10,
+                ])
+            )
+            ->willReturn(['results' => [], 'has_next_page' => false, 'next_cursor' => null]);
+
+        $mockApi->filterPools('ethereum', [
+            'page' => 1, // ignored
+            'limit' => 3,
+            'sortBy' => 'volume_24h', // legacy -> volume_usd_24h
+            'sortDir' => 'desc',
+            'volume24hMin' => 50000, // legacy -> volume_usd_24h_min
+            'txns24hMin' => 10,
+        ]);
     }
 
     public function testGetNetworkPoolsValidatesNetworkId(): void
@@ -158,18 +214,14 @@ class PoolsApiTest extends TestCase
 
     public function testListNetworkPools(): void
     {
-        // Mock the API response for listNetworkPools
+        // Mock the API response for listNetworkPools (cursor-paginated search shape)
         $expectedResponse = [
-            'pools' => [
-                ['id' => 'eth_wbtc', 'name' => 'ETH/WBTC'],
-                ['id' => 'eth_usdc', 'name' => 'ETH/USDC']
+            'results' => [
+                ['id' => '0xpool1'],
+                ['id' => '0xpool2']
             ],
-            'page_info' => [
-                'page' => 0,
-                'total_pages' => 5,
-                'items_on_page' => 2,
-                'total_items' => 10
-            ]
+            'has_next_page' => false,
+            'next_cursor' => null,
         ];
 
         // Use partial mock to only mock the getNetworkPools method
@@ -460,34 +512,22 @@ class PoolsApiTest extends TestCase
 
     public function testFetchAllNetworkPools(): void
     {
-        // Test responses for multiple pages
-        $responses = [
-            // Page 0
-            [
-                'pools' => [
-                    ['id' => 'pool1', 'name' => 'Pool 1'],
-                    ['id' => 'pool2', 'name' => 'Pool 2']
-                ],
-                'page_info' => [
-                    'page' => 0,
-                    'total_pages' => 2,
-                    'items_on_page' => 2,
-                    'total_items' => 4
-                ]
+        // Cursor-paginated responses: first page advertises a next cursor, second ends.
+        $page0 = [
+            'results' => [
+                ['id' => 'pool1'],
+                ['id' => 'pool2']
             ],
-            // Page 1
-            [
-                'pools' => [
-                    ['id' => 'pool3', 'name' => 'Pool 3'],
-                    ['id' => 'pool4', 'name' => 'Pool 4']
-                ],
-                'page_info' => [
-                    'page' => 1,
-                    'total_pages' => 2,
-                    'items_on_page' => 2,
-                    'total_items' => 4
-                ]
-            ]
+            'has_next_page' => true,
+            'next_cursor' => 'cursor1',
+        ];
+        $page1 = [
+            'results' => [
+                ['id' => 'pool3'],
+                ['id' => 'pool4']
+            ],
+            'has_next_page' => false,
+            'next_cursor' => null,
         ];
 
         // Mock the PoolsApi but only the getNetworkPools method
@@ -496,19 +536,18 @@ class PoolsApiTest extends TestCase
             ->onlyMethods(['getNetworkPools'])
             ->getMock();
 
-        // Set up expectations for each call to getNetworkPools
+        // The iterator threads next_cursor into the following request
         $mockApi->expects($this->exactly(2))
             ->method('getNetworkPools')
-            ->willReturnCallback(function($networkId, $options) use ($responses) {
-                $page = $options['page'] ?? 0;
-                return $responses[$page];
+            ->willReturnCallback(function($networkId, $options) use ($page0, $page1) {
+                return (($options['cursor'] ?? null) === 'cursor1') ? $page1 : $page0;
             });
 
         // Create a collector for results
         $allPools = [];
         $callback = function($poolsData, $page) use (&$allPools) {
-            if (isset($poolsData['pools'])) {
-                foreach ($poolsData['pools'] as $pool) {
+            if (isset($poolsData['results'])) {
+                foreach ($poolsData['results'] as $pool) {
                     $allPools[] = $pool;
                 }
             }

--- a/tests/DexPaprika/TokensApiTest.php
+++ b/tests/DexPaprika/TokensApiTest.php
@@ -350,4 +350,65 @@ class TokensApiTest extends TestCase
         $this->assertEquals('eth', $objectResult->id);
         $this->assertEquals('Ethereum', $objectResult->name);
     }
+
+    public function testGetTopTokensUsesSearchEndpoint(): void
+    {
+        // getTopTokens must hit /tokens/search, drop page, and map legacy sort fields.
+        $mockApi = $this->getMockBuilder(TokensApi::class)
+            ->setConstructorArgs([$this->createMockClient([])])
+            ->onlyMethods(['get'])
+            ->getMock();
+
+        $mockApi->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/networks/ethereum/tokens/search'),
+                $this->equalTo([
+                    'limit' => 5,
+                    'order_by' => 'volume_usd_24h',
+                    'sort' => 'asc',
+                ])
+            )
+            ->willReturn(['results' => [], 'has_next_page' => false, 'next_cursor' => null]);
+
+        $mockApi->getTopTokens('ethereum', [
+            'page' => 1, // ignored
+            'limit' => 5,
+            'orderBy' => 'volume_24h', // legacy -> volume_usd_24h
+            'sort' => 'asc',
+        ]);
+    }
+
+    public function testFilterTokensUsesSearchEndpointAndMapsParams(): void
+    {
+        // filterTokens must hit /tokens/search, send order_by + sort (not sort_by/sort_dir),
+        // drop page, and rename legacy filter params to canonical names.
+        $mockApi = $this->getMockBuilder(TokensApi::class)
+            ->setConstructorArgs([$this->createMockClient([])])
+            ->onlyMethods(['get'])
+            ->getMock();
+
+        $mockApi->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/networks/ethereum/tokens/search'),
+                $this->equalTo([
+                    'limit' => 3,
+                    'order_by' => 'fdv_usd',
+                    'sort' => 'desc',
+                    'volume_usd_24h_min' => 100000,
+                    'fdv_min' => 1000000,
+                ])
+            )
+            ->willReturn(['results' => [], 'has_next_page' => false, 'next_cursor' => null]);
+
+        $mockApi->filterTokens('ethereum', [
+            'page' => 1, // ignored
+            'limit' => 3,
+            'sortBy' => 'fdv', // legacy -> fdv_usd
+            'sortDir' => 'desc',
+            'volume24hMin' => 100000, // legacy -> volume_usd_24h_min
+            'fdvMin' => 1000000,
+        ]);
+    }
 }

--- a/tests/DexPaprika/Utils/SearchParamsTest.php
+++ b/tests/DexPaprika/Utils/SearchParamsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DexPaprika\Tests\Utils;
+
+use DexPaprika\Utils\SearchParams;
+use PHPUnit\Framework\TestCase;
+
+class SearchParamsTest extends TestCase
+{
+    public function testMapPoolSortFieldMapsLegacyValues(): void
+    {
+        $this->assertEquals('volume_usd_24h', SearchParams::mapPoolSortField('volume_usd'));
+        $this->assertEquals('txns_24h', SearchParams::mapPoolSortField('transactions'));
+        $this->assertEquals('price_change_percentage_24h', SearchParams::mapPoolSortField('last_price_change_usd_24h'));
+        $this->assertEquals('volume_usd_24h', SearchParams::mapPoolSortField('volume_24h'));
+        $this->assertEquals('volume_usd_7d', SearchParams::mapPoolSortField('volume_7d'));
+        $this->assertEquals('volume_usd_30d', SearchParams::mapPoolSortField('volume_30d'));
+        $this->assertEquals('liquidity_usd', SearchParams::mapPoolSortField('liquidity'));
+    }
+
+    public function testMapPoolSortFieldPassesCanonicalThrough(): void
+    {
+        foreach (['volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 'liquidity_usd', 'txns_24h', 'created_at', 'price_usd', 'price_change_percentage_24h'] as $field) {
+            $this->assertEquals($field, SearchParams::mapPoolSortField($field));
+        }
+    }
+
+    public function testMapPoolSortFieldFallsBackToDefault(): void
+    {
+        $this->assertEquals('volume_usd_24h', SearchParams::mapPoolSortField('not_a_field'));
+        $this->assertEquals('volume_usd_24h', SearchParams::mapPoolSortField(null));
+        $this->assertEquals('volume_usd_24h', SearchParams::mapPoolSortField(''));
+    }
+
+    public function testMapTokenSortFieldMapsLegacyValues(): void
+    {
+        $this->assertEquals('volume_usd_24h', SearchParams::mapTokenSortField('volume_24h'));
+        $this->assertEquals('txns_24h', SearchParams::mapTokenSortField('txns'));
+        $this->assertEquals('price_change_percentage_24h', SearchParams::mapTokenSortField('price_change'));
+        $this->assertEquals('fdv_usd', SearchParams::mapTokenSortField('fdv'));
+        $this->assertEquals('volume_usd_7d', SearchParams::mapTokenSortField('volume_7d'));
+        $this->assertEquals('volume_usd_30d', SearchParams::mapTokenSortField('volume_30d'));
+        // tokens/search 400s on price ordering, so price_usd folds back to volume.
+        $this->assertEquals('volume_usd_24h', SearchParams::mapTokenSortField('price_usd'));
+    }
+
+    public function testMapTokenSortFieldPassesCanonicalThrough(): void
+    {
+        foreach (['volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 'liquidity_usd', 'txns_24h', 'fdv_usd', 'created_at', 'price_change_percentage_24h'] as $field) {
+            $this->assertEquals($field, SearchParams::mapTokenSortField($field));
+        }
+    }
+
+    public function testMapTokenSortFieldFallsBackToDefault(): void
+    {
+        $this->assertEquals('volume_usd_24h', SearchParams::mapTokenSortField('bogus'));
+        $this->assertEquals('volume_usd_24h', SearchParams::mapTokenSortField(null));
+    }
+
+    public function testMapPoolFilterParamsRenamesLegacyKeys(): void
+    {
+        $mapped = SearchParams::mapPoolFilterParams([
+            'volume_24h_min' => 1,
+            'volume_24h_max' => 2,
+            'volume_7d_min' => 3,
+            'volume_7d_max' => 4,
+            'liquidity_usd_min' => 5,
+            'liquidity_usd_max' => 6,
+            'txns_24h_min' => 7,
+            'created_after' => 8,
+            'created_before' => 9,
+            'order_by' => 'volume_usd_24h',
+            'sort' => 'desc',
+            'limit' => 10,
+        ]);
+
+        $this->assertEquals([
+            'volume_usd_24h_min' => 1,
+            'volume_usd_24h_max' => 2,
+            'volume_usd_7d_min' => 3,
+            'volume_usd_7d_max' => 4,
+            'liquidity_usd_min' => 5,
+            'liquidity_usd_max' => 6,
+            'txns_24h_min' => 7,
+            'created_after' => 8,
+            'created_before' => 9,
+            'order_by' => 'volume_usd_24h',
+            'sort' => 'desc',
+            'limit' => 10,
+        ], $mapped);
+    }
+
+    public function testMapTokenFilterParamsRenamesLegacyKeys(): void
+    {
+        $mapped = SearchParams::mapTokenFilterParams([
+            'volume_24h_min' => 1,
+            'volume_24h_max' => 2,
+            'liquidity_usd_min' => 3,
+            'fdv_min' => 4,
+            'fdv_max' => 5,
+            'txns_24h_min' => 6,
+            'created_after' => 7,
+            'created_before' => 8,
+        ]);
+
+        $this->assertEquals([
+            'volume_usd_24h_min' => 1,
+            'volume_usd_24h_max' => 2,
+            'liquidity_usd_min' => 3,
+            'fdv_min' => 4,
+            'fdv_max' => 5,
+            'txns_24h_min' => 6,
+            'created_after' => 7,
+            'created_before' => 8,
+        ], $mapped);
+    }
+}

--- a/tests/test_new_endpoints.php
+++ b/tests/test_new_endpoints.php
@@ -29,7 +29,8 @@ test('pools->filterPools - basic', function () use ($client) {
     ]);
     assert(isset($result['results']), 'Missing results key');
     assert(count($result['results']) > 0, 'No results');
-    assert(isset($result['page_info']), 'Missing page_info');
+    assert(array_key_exists('has_next_page', $result), 'Missing has_next_page');
+    assert(array_key_exists('next_cursor', $result), 'Missing next_cursor');
     $pool = $result['results'][0];
     assert(isset($pool['id']), 'Pool missing id');
     assert(isset($pool['tokens']), 'Pool missing tokens');
@@ -51,13 +52,12 @@ test('pools->filterPools - multiple params', function () use ($client) {
 // 2. Top Tokens
 test('tokens->getTopTokens - basic', function () use ($client) {
     $result = $client->tokens->getTopTokens('ethereum', ['limit' => 5]);
-    assert(isset($result['tokens']), 'Missing tokens key');
-    assert(count($result['tokens']) > 0, 'No tokens');
-    assert(isset($result['page_info']), 'Missing page_info');
-    $token = $result['tokens'][0];
+    assert(isset($result['results']), 'Missing results key');
+    assert(count($result['results']) > 0, 'No tokens');
+    assert(array_key_exists('has_next_page', $result), 'Missing has_next_page');
+    $token = $result['results'][0];
     assert(isset($token['address']), 'Token missing address');
-    assert(isset($token['symbol']), 'Token missing symbol');
-    echo "   Top token: {$token['symbol']} at \${$token['price_usd']}\n";
+    echo "   Top token: {$token['address']} at \${$token['price_usd']}\n";
 });
 
 test('tokens->getTopTokens - with sort', function () use ($client) {
@@ -66,8 +66,8 @@ test('tokens->getTopTokens - with sort', function () use ($client) {
         'sort' => 'asc',
         'limit' => 3,
     ]);
-    assert(isset($result['tokens']), 'Missing tokens');
-    echo "   Got " . count($result['tokens']) . " tokens (asc)\n";
+    assert(isset($result['results']), 'Missing results');
+    echo "   Got " . count($result['results']) . " tokens (asc)\n";
 });
 
 // 3. Token Filter
@@ -76,13 +76,13 @@ test('tokens->filterTokens - basic', function () use ($client) {
         'volume24hMin' => 100000,
         'limit' => 5,
     ]);
-    // The token filter endpoint returns its rows under a 'data' key (not 'results')
-    assert(isset($result['data']), 'Missing data key');
-    assert(count($result['data']) > 0, 'No results');
-    assert(isset($result['page_info']), 'Missing page_info');
-    $token = $result['data'][0];
+    // The tokens/search endpoint returns its rows under a 'results' key
+    assert(isset($result['results']), 'Missing results key');
+    assert(count($result['results']) > 0, 'No results');
+    assert(array_key_exists('has_next_page', $result), 'Missing has_next_page');
+    $token = $result['results'][0];
     assert(isset($token['address']), 'Token missing address');
-    echo "   Got " . count($result['data']) . " filtered tokens\n";
+    echo "   Got " . count($result['results']) . " filtered tokens\n";
 });
 
 test('tokens->filterTokens - with FDV', function () use ($client) {
@@ -91,8 +91,8 @@ test('tokens->filterTokens - with FDV', function () use ($client) {
         'fdvMin' => 1000000,
         'limit' => 3,
     ]);
-    assert(isset($result['data']), 'Missing data');
-    echo "   Got " . count($result['data']) . " tokens with FDV filter\n";
+    assert(isset($result['results']), 'Missing results');
+    echo "   Got " . count($result['results']) . " tokens with FDV filter\n";
 });
 
 // 4. Multi Prices
@@ -130,7 +130,7 @@ test('existing: networks->getNetworks', function () use ($client) {
 
 test('existing: pools->getNetworkPools', function () use ($client) {
     $pools = $client->pools->getNetworkPools('ethereum', ['limit' => 2]);
-    assert(isset($pools['pools']), 'Missing pools');
+    assert(isset($pools['results']), 'Missing results');
 });
 
 test('existing: utils->getStats', function () use ($client) {


### PR DESCRIPTION
DexPaprika removed four REST endpoints (HTTP 410): `/networks/{network}/pools`, `/networks/{network}/pools/filter`, `/networks/{network}/tokens/top`, `/networks/{network}/tokens/filter`. The network-pools, pool-filter, top-tokens, and token-filter methods were erroring.

## Fix

Repoint all four to the unified search endpoints (method names + signatures unchanged for back-compat):

- network pools, pool filter -> `/networks/{network}/pools/search`
- top tokens, token filter -> `/networks/{network}/tokens/search`

A shared helper normalizes legacy sort-field values (`volume_usd` -> `volume_usd_24h`, `transactions` -> `txns_24h`, `last_price_change_usd_24h` -> `price_change_percentage_24h`, ...) and legacy filter param names (`volume_24h_min` -> `volume_usd_24h_min`, ...). The search endpoints **400** on the old names, so this mapping is required; the filter methods now send `order_by` + `sort`. Token sort by price falls back to volume (the token search rejects price ordering).

Responses are cursor-paginated: rows under `results` with `has_next_page` + `next_cursor` (no `page_info`); models use the new field names (`id` not `address` for pools, `transactions_24h`, `price_change_percentage_24h`, `fdv_usd`, ...). The new flat token shape has no name/symbol/buys/sells, so token models reflect what the API returns. Legacy params are still accepted; `page` is kept in signatures but no longer sent (an optional `cursor` is added).

## Verified

Live against api.dexpaprika.com: build and test suite pass; all four methods return real rows in both default and JSON usage; legacy sort values map instead of 400; zero em/en dashes.

## Release

After merge: tag the release (e.g. `git tag v1.2.0 && git push origin v1.2.0`); Packagist auto-syncs. The pre-existing deprecated global `/pools` list method is intentionally left to surface its deprecation (out of scope).