### PR TITLE
Fix DeprecationException message + surface replacement; bump to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0] - 2026-06-30
+## [1.4.0] - 2026-07-01
+
+Version jumps from the previous `v1.3.0` release tag straight to `1.4.0` (the migration below was first tagged `v1.2.0`, which sorted under the existing `v1.3.0`; `1.4.0` supersedes both so Composer serves the migrated code).
 
 ### Changed
+- **Deprecation errors now surface the replacement**: on a removed-endpoint response the SDK builds `DeprecationException` from the API body's `message` and appends `Use <replacement> instead.` (previously the message was the literal `"Unknown error"`), and exposes `DeprecationException::getReplacement()`. Generic: it keys on any error body carrying a `replacement` field.
 - **Unified search endpoints**: `PoolsApi::getNetworkPools()` and `PoolsApi::filterPools()` now call `/networks/{network}/pools/search`; `TokensApi::getTopTokens()` and `TokensApi::filterTokens()` now call `/networks/{network}/tokens/search`. The previous list/filter/top endpoints return `410 Gone`.
 - **Cursor pagination**: these four methods now return `results`, `has_next_page` and `next_cursor` instead of `pools`/`tokens` plus `page_info`. The `page` option is still accepted but ignored; pass `cursor` to page through results.
 - **Filter methods** now send `order_by` + `sort` (previously `sort_by` + `sort_dir`).

--- a/src/DexPaprika/Api/BaseApi.php
+++ b/src/DexPaprika/Api/BaseApi.php
@@ -383,9 +383,20 @@ abstract class BaseApi
      */
     protected function createExceptionFromResponse(int $statusCode, ?array $errorData = null): DexPaprikaApiException
     {
-        $message = $errorData['error'] ?? 'Unknown error';
-        
-        return match (true) {
+        // Prefer the API's "message" field; fall back to legacy "error", then a generic label.
+        // The "??" chain is null-safe even when $errorData is null.
+        $message = $errorData['message'] ?? $errorData['error'] ?? 'Unknown error';
+
+        // Generic deprecation self-documentation: any error whose body carries a
+        // "replacement" hint (regardless of status code) gets that hint surfaced in
+        // the message, so future deprecations document their own migration path.
+        $replacement = null;
+        if (isset($errorData['replacement']) && is_string($errorData['replacement']) && $errorData['replacement'] !== '') {
+            $replacement = $errorData['replacement'];
+            $message .= ' Use ' . $replacement . ' instead.';
+        }
+
+        $exception = match (true) {
             $statusCode === 404 => new NotFoundException($message, $statusCode, $errorData),
             $statusCode === 401 => new AuthenticationException($message, $statusCode, $errorData),
             $statusCode === 410 => new DeprecationException($message, $statusCode, $errorData),
@@ -394,5 +405,12 @@ abstract class BaseApi
             $statusCode >= 400 => new ClientException($message, $statusCode, $errorData),
             default => new DexPaprikaApiException($message, $statusCode, $errorData),
         };
+
+        // Enrich the typed deprecation error with a direct replacement accessor.
+        if ($replacement !== null && $exception instanceof DeprecationException) {
+            $exception->setReplacement($replacement);
+        }
+
+        return $exception;
     }
 }

--- a/src/DexPaprika/Client.php
+++ b/src/DexPaprika/Client.php
@@ -75,7 +75,7 @@ class Client
     /**
      * SDK version
      */
-    public const VERSION = '1.2.0';
+    public const VERSION = '1.4.0';
 
     /**
      * Create a new DexPaprika client

--- a/src/DexPaprika/Exception/DeprecationException.php
+++ b/src/DexPaprika/Exception/DeprecationException.php
@@ -3,12 +3,49 @@
 namespace DexPaprika\Exception;
 
 /**
- * Exception thrown when a deprecated API endpoint or method is used
+ * Exception thrown when a deprecated API endpoint or method is used.
+ *
+ * When the API response body carries a "replacement" hint, it is captured
+ * automatically and exposed via getReplacement() so callers can migrate to the
+ * current endpoint. The hint is also folded into the exception message.
  */
 class DeprecationException extends DexPaprikaApiException
 {
+    /**
+     * Suggested replacement endpoint or method, when the API provides one.
+     */
+    protected ?string $replacement = null;
+
     public function __construct(string $message = "", int $code = 410, ?array $errorData = null, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $errorData, $previous);
+
+        // Self-populate the replacement hint from the API error body when present,
+        // so a DeprecationException always knows where to point callers next.
+        if (isset($errorData['replacement']) && is_string($errorData['replacement']) && $errorData['replacement'] !== '') {
+            $this->replacement = $errorData['replacement'];
+        }
     }
-} 
+
+    /**
+     * Get the suggested replacement endpoint or method, if the API provided one.
+     *
+     * @return string|null
+     */
+    public function getReplacement(): ?string
+    {
+        return $this->replacement;
+    }
+
+    /**
+     * Set the suggested replacement endpoint or method.
+     *
+     * @param string $replacement
+     * @return self
+     */
+    public function setReplacement(string $replacement): self
+    {
+        $this->replacement = $replacement;
+        return $this;
+    }
+}

--- a/tests/DexPaprika/Api/DeprecationTest.php
+++ b/tests/DexPaprika/Api/DeprecationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace DexPaprika\Tests\Api;
+
+use DexPaprika\Api\NetworksApi;
+use DexPaprika\Config;
+use DexPaprika\Exception\ClientException;
+use DexPaprika\Exception\DeprecationException;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class DeprecationTest extends TestCase
+{
+    /**
+     * Build a NetworksApi wired to a fixed set of mock responses.
+     *
+     * @param array<int, Response> $responses
+     * @param array<int, mixed> $container History container passed by reference
+     */
+    private function apiWithResponses(array $responses, array &$container): NetworksApi
+    {
+        $mock = new MockHandler($responses);
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push(Middleware::history($container));
+        $httpClient = new GuzzleClient(['handler' => $handlerStack]);
+
+        $config = new Config();
+        $config->setMaxRetries(0);
+
+        return new NetworksApi($httpClient, false, $config);
+    }
+
+    /**
+     * A 410 with a "replacement" hint surfaces both the message and the replacement.
+     */
+    public function testDeprecationSurfacesReplacement(): void
+    {
+        $body = json_encode([
+            'code' => 410,
+            'message' => 'endpoint removed',
+            'replacement' => '/networks/:network/pools/search',
+        ]);
+
+        $container = [];
+        $api = $this->apiWithResponses([new Response(410, [], $body)], $container);
+
+        try {
+            $api->getNetworks();
+            $this->fail('Expected DeprecationException was not thrown');
+        } catch (DeprecationException $e) {
+            $this->assertSame(410, $e->getCode());
+            $this->assertStringContainsString('endpoint removed', $e->getMessage());
+            $this->assertStringContainsString('Use /networks/:network/pools/search instead.', $e->getMessage());
+            $this->assertSame('/networks/:network/pools/search', $e->getReplacement());
+            $this->assertIsArray($e->getErrorData());
+            $this->assertSame('/networks/:network/pools/search', $e->getErrorData()['replacement']);
+            // 410 is not retryable: a single request must have been made.
+            $this->assertCount(1, $container);
+        }
+    }
+
+    /**
+     * The replacement hint is generic: any error status carrying it gets it surfaced.
+     */
+    public function testGenericReplacementOnNon410Status(): void
+    {
+        $body = json_encode([
+            'message' => 'gone for good',
+            'replacement' => '/v2/thing',
+        ]);
+
+        $container = [];
+        $api = $this->apiWithResponses([new Response(400, [], $body)], $container);
+
+        try {
+            $api->getNetworks();
+            $this->fail('Expected exception was not thrown');
+        } catch (ClientException $e) {
+            $this->assertStringContainsString('gone for good', $e->getMessage());
+            $this->assertStringContainsString('Use /v2/thing instead.', $e->getMessage());
+        }
+    }
+
+    /**
+     * When no "replacement" is present, behavior falls back to the plain message.
+     */
+    public function testFallsBackWhenNoReplacement(): void
+    {
+        $body = json_encode([
+            'error' => 'plain old error',
+        ]);
+
+        $container = [];
+        $api = $this->apiWithResponses([new Response(400, [], $body)], $container);
+
+        try {
+            $api->getNetworks();
+            $this->fail('Expected exception was not thrown');
+        } catch (ClientException $e) {
+            $this->assertSame('plain old error', $e->getMessage());
+            $this->assertStringNotContainsString('instead.', $e->getMessage());
+        }
+    }
+
+    /**
+     * A non-JSON error body degrades gracefully to the generic message.
+     */
+    public function testNonJsonBodyFallsBack(): void
+    {
+        $container = [];
+        $api = $this->apiWithResponses([new Response(400, [], 'not json at all')], $container);
+
+        try {
+            $api->getNetworks();
+            $this->fail('Expected exception was not thrown');
+        } catch (ClientException $e) {
+            $this->assertSame('Unknown error', $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
**Supersedes #11** (folds its `1.4.0` version bump in here — please close #11).

Fixes the `DeprecationException` message bug: it read `$errorData['error']`, but the 410 body has `message`/`replacement` (no `error` key), so the message came out as the literal `"Unknown error"`. Now built from `message` (fallback `error`), appending `Use <replacement> instead.` when present, plus a new `DeprecationException::getReplacement()`. Generic across any error body with a `replacement`; defensive fallback. Version `1.2.0 -> 1.4.0` (supersedes the pre-existing `v1.3.0` tag). `composer test` 105 passed. After merge: tag `v1.4.0` (Packagist auto-syncs).