### PR TITLE
Update chain coverage to 36+

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The `page` option is still accepted for backward compatibility but is ignored.
 ## Features
 
 - Simple and intuitive PHP interface to all DexPaprika API endpoints
-- Access data from 33+ blockchain networks
+- Access data from 36+ blockchain networks
 - Query information about DEXes, liquidity pools, and tokens
 - Get detailed price information, trading volume, and transactions
 - **Filter pools and tokens** by volume, liquidity, FDV, transactions, and creation date


### PR DESCRIPTION
DexPaprika now indexes 36 chains, so the 33+ blockchain networks line in the README features list was stale.

Verified live before opening this PR:

```
curl -s https://api.dexpaprika.com/stats
{"chains":36,"factories":231,"pools":36306148,"tokens":33574382}
```

Docs-only change, no code touched.