### PR TITLE
fix: migrate getTokenPools to /pools/search (token-pools endpoint removed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API endpoint removed (410 Gone)**: `GET /networks/{network}/tokens/{address}/pools` was removed by DexPaprika. `TokensApi::getTokenPools()` (and its aliases `listTokenPools()`, `getTokenPairs()`, `listTokenPairs()`) now call the unified `/networks/{network}/pools/search` endpoint with its new `token_address` parameter. Method signatures are unchanged.
 - **Cursor pagination**: `getTokenPools()` now returns `results`, `has_next_page` and `next_cursor` instead of `pools` plus `page_info`. The `page` option is still accepted but ignored; pass `cursor` to page through results. `fetchAllTokenPools()` follows `next_cursor` internally.
 - **Network-scoped only**: the cross-network `/pools/search` endpoint accepts `token_address` but silently ignores it, so a network is always required.
-- **Removed options**: the `address` (pair filter) and `reorder` (pair-perspective flip) options have no `/pools/search` equivalent and are now ignored; repeating `token_address` on the API side is last-wins, not a pair filter. Filter the returned pools client-side to match a pair.
+- **Removed options**: the `address` (pair filter) and `reorder` (pair-perspective flip) options have no `/pools/search` equivalent and are now ignored. Repeating `token_address` does not act as a pair filter; the API uses only one of the values (not guaranteed by order). Filter the returned pools client-side to match a pair.
 - Legacy `orderBy` values (e.g. `volume_usd`) are mapped to the canonical search names automatically. An unknown token address returns an empty result set, not an error.
 - Updated SDK VERSION constant to 1.5.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-07-15
+
+### Changed
+- **API endpoint removed (410 Gone)**: `GET /networks/{network}/tokens/{address}/pools` was removed by DexPaprika. `TokensApi::getTokenPools()` (and its aliases `listTokenPools()`, `getTokenPairs()`, `listTokenPairs()`) now call the unified `/networks/{network}/pools/search` endpoint with its new `token_address` parameter. Method signatures are unchanged.
+- **Cursor pagination**: `getTokenPools()` now returns `results`, `has_next_page` and `next_cursor` instead of `pools` plus `page_info`. The `page` option is still accepted but ignored; pass `cursor` to page through results. `fetchAllTokenPools()` follows `next_cursor` internally.
+- **Network-scoped only**: the cross-network `/pools/search` endpoint accepts `token_address` but silently ignores it, so a network is always required.
+- **Removed options**: the `address` (pair filter) and `reorder` (pair-perspective flip) options have no `/pools/search` equivalent and are now ignored; repeating `token_address` on the API side is last-wins, not a pair filter. Filter the returned pools client-side to match a pair.
+- Legacy `orderBy` values (e.g. `volume_usd`) are mapped to the canonical search names automatically. An unknown token address returns an empty result set, not an error.
+- Updated SDK VERSION constant to 1.5.0.
+
 ## [1.4.0] - 2026-07-01
 
 Version jumps from the previous `v1.3.0` release tag straight to `1.4.0` (the migration below was first tagged `v1.2.0`, which sorted under the existing `v1.3.0`; `1.4.0` supersedes both so Composer serves the migrated code).

--- a/README.md
+++ b/README.md
@@ -239,11 +239,23 @@ $tokenDetails = $client->tokens->getTokenDetails('ethereum', '0xc02aaa39b223fe8d
 // Find token by name or address
 $token = $client->tokens->findToken('ethereum', 'WETH');
 
-// Get pools containing a specific token (UPDATED in v1.3.0)
+// Get pools containing a specific token (UPDATED in v1.5.0).
+// Backed by /networks/{network}/pools/search with token_address: the filter is
+// network-scoped, rows come back under 'results', and pagination is
+// cursor-based ('cursor' option / 'next_cursor' in the response).
 $tokenPools = $client->tokens->getTokenPools('ethereum', '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', [
     'limit' => 20,
-    'reorder' => true  // NEW: Reorder pools so the token becomes the primary token for metrics
 ]);
+foreach ($tokenPools['results'] as $pool) {
+    echo $pool['id'] . ': ' . $pool['volume_usd_24h'] . "\n";
+}
+
+// The removed endpoint's 'address' (pair filter) and 'reorder' options have no
+// /pools/search equivalent and are ignored. To match a pair, filter client-side:
+$usdc = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+$pairPools = array_filter($tokenPools['results'], function ($pool) use ($usdc) {
+    return in_array($usdc, array_column($pool['tokens'] ?? [], 'id'), true);
+});
 ```
 
 ### Pool Filtering

--- a/examples/basic_usage.php
+++ b/examples/basic_usage.php
@@ -81,16 +81,22 @@ try {
     echo "- Price: $" . number_format($weth['price_usd'], 2) . "\n";
     echo "- 24h Volume: $" . number_format($weth['volume_usd_24h'], 2) . "\n";
     
-    // Get pools for WETH-USDC pair
+    // Get top pools containing WETH (network-scoped /pools/search filter,
+    // cursor-paginated: rows under 'results'). The old pair filter ('address')
+    // was removed with the /tokens/{address}/pools endpoint, so match pairs
+    // client-side instead.
     echo "\nTop WETH-USDC Pools:\n";
     $usdcAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-    $wethUsdcPools = $client->tokens->getTokenPools('ethereum', $wethAddress, [
-        'limit' => 3,
-        'address' => $usdcAddress
+    $wethPools = $client->tokens->getTokenPools('ethereum', $wethAddress, [
+        'limit' => 10,
     ]);
-    
-    foreach ($wethUsdcPools['pools'] as $index => $pool) {
-        echo ($index + 1) . ". {$pool['dex_name']}: $" . number_format($pool['volume_usd'], 2) . " 24h volume\n";
+
+    $wethUsdcPools = array_values(array_filter($wethPools['results'], function ($pool) use ($usdcAddress) {
+        return in_array($usdcAddress, array_column($pool['tokens'] ?? [], 'id'), true);
+    }));
+
+    foreach (array_slice($wethUsdcPools, 0, 3) as $index => $pool) {
+        echo ($index + 1) . ". {$pool['dex_name']}: $" . number_format($pool['volume_usd_24h'], 2) . " 24h volume\n";
     }
 
 } catch (NotFoundException $e) {

--- a/src/DexPaprika/Api/TokensApi.php
+++ b/src/DexPaprika/Api/TokensApi.php
@@ -69,8 +69,9 @@ class TokensApi extends BaseApi
      *
      * The removed endpoint's pair filter ($address) and metric reordering
      * ($reorder) have no /pools/search equivalent: both options are deprecated
-     * and ignored (repeating token_address is last-wins on the API side, not a
-     * pair filter). Filter the returned pools client-side to match a pair.
+     * and ignored. Repeating token_address does not act as a pair filter; the
+     * API uses only one of the values (not guaranteed by order). Filter the
+     * returned pools client-side to match a pair.
      *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param string $tokenAddress Token address or identifier

--- a/src/DexPaprika/Api/TokensApi.php
+++ b/src/DexPaprika/Api/TokensApi.php
@@ -57,67 +57,71 @@ class TokensApi extends BaseApi
     }
 
     /**
-     * Get a list of top liquidity pools for a specific token on a network
+     * Get a list of top liquidity pools that contain a specific token on a network
+     *
+     * Backed by the unified /networks/{network}/pools/search endpoint with its
+     * token_address parameter (the previous /tokens/{address}/pools endpoint
+     * returns 410 Gone). The filter is network-scoped only: the cross-network
+     * /pools/search endpoint accepts token_address but silently ignores it, so a
+     * network is always required. The response is cursor-paginated and shaped as
+     * {@code results[], has_next_page, next_cursor, query}. An unknown token
+     * address returns an empty result set, not an error.
+     *
+     * The removed endpoint's pair filter ($address) and metric reordering
+     * ($reorder) have no /pools/search equivalent: both options are deprecated
+     * and ignored (repeating token_address is last-wins on the API side, not a
+     * pair filter). Filter the returned pools client-side to match a pair.
      *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param string $tokenAddress Token address or identifier
      * @param array<string, mixed> $options Additional options:
-     *  - string $address: Filter pools that contain this additional token address
-     *  - bool $reorder: If true, reorders the pool so that the token becomes the primary token for all metrics (default: false)
-     *  - int $page: Page number for pagination (default: 0)
+     *  - int $page: Accepted for backward compatibility but ignored (the endpoint is cursor-based)
+     *  - string $cursor: Opaque cursor from a previous response's next_cursor
      *  - int $limit: Number of items per page (default: 10, max: 100)
-     *  - string $orderBy: Field to order by (default: 'volume_usd')
+     *  - string $orderBy: Field to order by (legacy values mapped, default: 'volume_usd_24h')
      *  - string $sort: Sort order (default: 'desc')
+     *  - string $address: Deprecated and ignored (no pair filter on /pools/search)
+     *  - bool $reorder: Deprecated and ignored (no equivalent on /pools/search)
      *  - bool $asObject: Whether to return the response as an object (default: false)
-     * @return array<string, mixed>|object List of pools containing the token
+     * @return array<string, mixed>|object Pools containing the token (results[] + has_next_page + next_cursor)
      */
     public function getTokenPools(string $networkId, string $tokenAddress, array $options = [])
     {
-        $params = [];
-
-        if (isset($options['address'])) {
-            $params['address'] = $options['address'];
-        }
-
-        if (isset($options['reorder'])) {
-            $params['reorder'] = $options['reorder'];
-        }
-
-        if (isset($options['page'])) {
-            $params['page'] = $options['page'];
-        }
+        $params = [
+            'token_address' => $tokenAddress,
+        ];
 
         if (isset($options['limit'])) {
             $params['limit'] = $options['limit'];
         }
 
         if (isset($options['orderBy'])) {
-            $params['order_by'] = $options['orderBy'];
+            $params['order_by'] = SearchParams::mapPoolSortField($options['orderBy']);
         }
 
         if (isset($options['sort'])) {
             $params['sort'] = $options['sort'];
         }
 
-        $response = $this->get("/networks/{$networkId}/tokens/{$tokenAddress}/pools", $params);
-        
+        if (isset($options['cursor'])) {
+            $params['cursor'] = $options['cursor'];
+        }
+
+        $response = $this->get("/networks/{$networkId}/pools/search", $params);
+
         return $this->transformResponse($response, $options['asObject'] ?? false);
     }
 
     /**
      * List pools for a specific token (alias for getTokenPools)
      *
+     * See getTokenPools() for the /pools/search-backed behaviour, options and
+     * the deprecated $address / $reorder notes.
+     *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param string $tokenAddress Token address or identifier
-     * @param array<string, mixed> $options Additional options:
-     *  - string $address: Filter pools that contain this additional token address
-     *  - bool $reorder: If true, reorders the pool so that the token becomes the primary token for all metrics (default: false)
-     *  - int $page: Page number for pagination (default: 0)
-     *  - int $limit: Number of items per page (default: 10, max: 100)
-     *  - string $orderBy: Field to order by (default: 'volume_usd')
-     *  - string $sort: Sort order (default: 'desc')
-     *  - bool $asObject: Whether to return the response as an object (default: false)
-     * @return array<string, mixed>|object List of pools containing the token
+     * @param array<string, mixed> $options Additional options (see getTokenPools())
+     * @return array<string, mixed>|object Pools containing the token (results[] + has_next_page + next_cursor)
      */
     public function listTokenPools(string $networkId, string $tokenAddress, array $options = [])
     {
@@ -127,15 +131,14 @@ class TokensApi extends BaseApi
     /**
      * Get token pairs involving a specific token
      *
+     * Alias for getTokenPools(); see that method for the /pools/search-backed
+     * behaviour. Note that a dedicated pair filter no longer exists: this
+     * returns all pools containing the token, cursor-paginated.
+     *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param string $tokenAddress Token address or identifier
-     * @param array<string, mixed> $options Additional options:
-     *  - int $page: Page number for pagination (default: 0)
-     *  - int $limit: Number of items per page (default: 10)
-     *  - string $orderBy: Field to order by ('volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at')
-     *  - string $sort: Sort order ('asc' or 'desc')
-     *  - bool $asObject: Whether to return the response as an object (default: false)
-     * @return array<string, mixed>|object List of token pairs
+     * @param array<string, mixed> $options Additional options (see getTokenPools())
+     * @return array<string, mixed>|object Pools containing the token (results[] + has_next_page + next_cursor)
      */
     public function getTokenPairs(string $networkId, string $tokenAddress, array $options = [])
     {
@@ -332,17 +335,20 @@ class TokensApi extends BaseApi
     /**
      * Fetch all pools containing a specific token using a callback function
      *
+     * Pages through the cursor-paginated /networks/{network}/pools/search
+     * endpoint (with token_address) by following next_cursor.
+     *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param string $tokenAddress Token address or identifier
      * @param callable $callback Function to call for each page of pools: function(array|object $pools, int $page): bool
      *                          Return false from the callback to stop pagination
      * @param array<string, mixed> $options Additional options:
-     *  - string $address: Filter pools that contain this additional token address
-     *  - bool $reorder: If true, reorders the pool so that the token becomes the primary token for all metrics (default: false)
      *  - int $limit: Number of items per page (default: 10, max: 100)
-     *  - string $orderBy: Field to order by (default: 'volume_usd')
+     *  - string $orderBy: Field to order by (legacy values mapped, default: 'volume_usd_24h')
      *  - string $sort: Sort order (default: 'desc')
      *  - int $maxPages: Maximum number of pages to fetch (default: 10, use 0 for unlimited)
+     *  - string $address: Deprecated and ignored (no pair filter on /pools/search)
+     *  - bool $reorder: Deprecated and ignored (no equivalent on /pools/search)
      *  - bool $asObject: Whether to return the response as an object (default: false)
      * @return int Total number of pages fetched
      */
@@ -350,48 +356,47 @@ class TokensApi extends BaseApi
     {
         $page = 0;
         $totalPages = 0;
-        $limit = $options['limit'] ?? 10;
         $maxPages = $options['maxPages'] ?? 10;
-        
+
         // Set asObject and remove from options to pass to API
         $asObject = $options['asObject'] ?? false;
         $apiOptions = $options;
-        unset($apiOptions['maxPages'], $apiOptions['asObject']);
-        $apiOptions['page'] = $page;
-        
+        unset($apiOptions['maxPages'], $apiOptions['asObject'], $apiOptions['cursor']);
+
         do {
             $response = $this->getTokenPools($networkId, $tokenAddress, array_merge($apiOptions, ['asObject' => $asObject]));
-            
+
             $continueProcessing = $callback($response, $page);
             $totalPages++;
             $page++;
-            
-            // Update the page number for the next request
-            $apiOptions['page'] = $page;
-            
+
             // Check if we should continue processing
             if ($continueProcessing === false) {
                 break;
             }
-            
+
             // Check if we've reached the maximum number of pages
             if ($maxPages > 0 && $page >= $maxPages) {
                 break;
             }
-            
-            // Check if we've reached the end of available pools
+
+            // Follow the cursor; stop when the API reports no further pages
             if ($asObject) {
-                if (!isset($response->pools) || count($response->pools) < $limit) {
-                    break;
-                }
+                $hasNext = (bool) ($response->has_next_page ?? false);
+                $cursor = $response->next_cursor ?? null;
             } else {
-                if (!isset($response['pools']) || count($response['pools']) < $limit) {
-                    break;
-                }
+                $hasNext = (bool) ($response['has_next_page'] ?? false);
+                $cursor = $response['next_cursor'] ?? null;
             }
-            
+
+            if (!$hasNext || $cursor === null || $cursor === '') {
+                break;
+            }
+
+            $apiOptions['cursor'] = $cursor;
+
         } while (true);
-        
+
         return $totalPages;
     }
 

--- a/src/DexPaprika/Client.php
+++ b/src/DexPaprika/Client.php
@@ -75,7 +75,7 @@ class Client
     /**
      * SDK version
      */
-    public const VERSION = '1.4.0';
+    public const VERSION = '1.5.0';
 
     /**
      * Create a new DexPaprika client

--- a/tests/DexPaprika/Integration/IntegrationTest.php
+++ b/tests/DexPaprika/Integration/IntegrationTest.php
@@ -75,16 +75,37 @@ class IntegrationTest extends TestCase
     
     public function testGetTokenPools(): void
     {
-        // Note: This test assumes that Ethereum network and WETH token exist
+        // Note: This test assumes that Ethereum network and WETH token exist.
+        // Token pools come from the cursor-paginated /pools/search endpoint.
+        $weth = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
         $tokenPools = $this->client->tokens->getTokenPools(
-            'ethereum', 
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            'ethereum',
+            $weth,
             ['limit' => 3]
         );
-        
+
         $this->assertIsArray($tokenPools);
-        $this->assertArrayHasKey('pools', $tokenPools);
-        $this->assertLessThanOrEqual(3, count($tokenPools['pools']));
+        $this->assertArrayHasKey('results', $tokenPools);
+        $this->assertArrayHasKey('has_next_page', $tokenPools);
+        $this->assertNotEmpty($tokenPools['results']);
+        $this->assertLessThanOrEqual(3, count($tokenPools['results']));
+
+        // Every returned pool must contain the requested token
+        foreach ($tokenPools['results'] as $pool) {
+            $tokenIds = array_column($pool['tokens'] ?? [], 'id');
+            $this->assertContains($weth, $tokenIds);
+        }
+
+        // Follow the cursor to the next page
+        if (($tokenPools['has_next_page'] ?? false) && !empty($tokenPools['next_cursor'])) {
+            $nextPage = $this->client->tokens->getTokenPools(
+                'ethereum',
+                $weth,
+                ['limit' => 3, 'cursor' => $tokenPools['next_cursor']]
+            );
+            $this->assertNotEmpty($nextPage['results']);
+            $this->assertNotEquals($tokenPools['results'][0]['id'], $nextPage['results'][0]['id']);
+        }
     }
     
     public function testGetTopPools(): void

--- a/tests/DexPaprika/TokensApiTest.php
+++ b/tests/DexPaprika/TokensApiTest.php
@@ -105,26 +105,20 @@ class TokensApiTest extends TestCase
     public function testGetTokenPools(): void
     {
         $expectedResponse = [
-            'pools' => [
+            'results' => [
                 [
-                    'id' => 'uniswap-v2-eth-usdt',
-                    'address' => '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
-                    'name' => 'ETH/USDT',
+                    'id' => '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
+                    'chain' => 'ethereum',
                     'volume_usd_24h' => 150000000,
                 ],
                 [
-                    'id' => 'uniswap-v2-eth-dai',
-                    'address' => '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11',
-                    'name' => 'ETH/DAI',
+                    'id' => '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11',
+                    'chain' => 'ethereum',
                     'volume_usd_24h' => 75000000,
                 ],
             ],
-            'page_info' => [
-                'page' => 0,
-                'total_pages' => 1,
-                'items_on_page' => 2,
-                'total_items' => 2,
-            ],
+            'has_next_page' => false,
+            'next_cursor' => null,
         ];
 
         $mockClient = $this->createMockClient([
@@ -140,16 +134,49 @@ class TokensApiTest extends TestCase
         $this->assertEquals($expectedResponse, $result);
     }
 
+    public function testGetTokenPoolsUsesPoolSearchEndpoint(): void
+    {
+        // getTokenPools must hit /pools/search with token_address, drop page and
+        // the removed address/reorder params, and map legacy sort fields.
+        $mockApi = $this->getMockBuilder(TokensApi::class)
+            ->setConstructorArgs([$this->createMockClient([])])
+            ->onlyMethods(['get'])
+            ->getMock();
+
+        $mockApi->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/networks/ethereum/pools/search'),
+                $this->equalTo([
+                    'token_address' => '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+                    'limit' => 5,
+                    'order_by' => 'volume_usd_24h',
+                    'sort' => 'desc',
+                ])
+            )
+            ->willReturn(['results' => [], 'has_next_page' => false, 'next_cursor' => null]);
+
+        $mockApi->getTokenPools('ethereum', '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', [
+            'page' => 2, // ignored: cursor-paginated
+            'limit' => 5,
+            'orderBy' => 'volume_usd', // legacy -> volume_usd_24h
+            'sort' => 'desc',
+            'address' => '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // deprecated, not sent
+            'reorder' => true, // deprecated, not sent
+        ]);
+    }
+
     public function testListTokenPools(): void
     {
         $expectedResponse = [
-            'pools' => [
+            'results' => [
                 [
-                    'id' => 'uniswap-v2-eth-usdt',
-                    'address' => '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
-                    'name' => 'ETH/USDT',
+                    'id' => '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
+                    'chain' => 'ethereum',
                 ],
             ],
+            'has_next_page' => false,
+            'next_cursor' => null,
         ];
 
         $mockClient = $this->createMockClient([
@@ -165,13 +192,14 @@ class TokensApiTest extends TestCase
     public function testGetTokenPairs(): void
     {
         $expectedResponse = [
-            'pools' => [
+            'results' => [
                 [
-                    'id' => 'uniswap-v2-eth-usdt',
-                    'address' => '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
-                    'name' => 'ETH/USDT',
+                    'id' => '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
+                    'chain' => 'ethereum',
                 ],
             ],
+            'has_next_page' => false,
+            'next_cursor' => null,
         ];
 
         $mockClient = $this->createMockClient([
@@ -187,13 +215,14 @@ class TokensApiTest extends TestCase
     public function testListTokenPairs(): void
     {
         $expectedResponse = [
-            'pools' => [
+            'results' => [
                 [
-                    'id' => 'uniswap-v2-eth-usdt',
-                    'address' => '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
-                    'name' => 'ETH/USDT',
+                    'id' => '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
+                    'chain' => 'ethereum',
                 ],
             ],
+            'has_next_page' => false,
+            'next_cursor' => null,
         ];
 
         $mockClient = $this->createMockClient([
@@ -209,35 +238,25 @@ class TokensApiTest extends TestCase
     public function testFetchAllTokenPools(): void
     {
         $response1 = [
-            'pools' => [
+            'results' => [
                 [
-                    'id' => 'uniswap-v2-eth-usdt',
-                    'address' => '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
-                    'name' => 'ETH/USDT',
+                    'id' => '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
+                    'chain' => 'ethereum',
                 ],
             ],
-            'page_info' => [
-                'page' => 0,
-                'total_pages' => 2,
-                'items_on_page' => 1,
-                'total_items' => 2,
-            ],
+            'has_next_page' => true,
+            'next_cursor' => 'cursor-page-2',
         ];
 
         $response2 = [
-            'pools' => [
+            'results' => [
                 [
-                    'id' => 'uniswap-v2-eth-dai',
-                    'address' => '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11',
-                    'name' => 'ETH/DAI',
+                    'id' => '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11',
+                    'chain' => 'ethereum',
                 ],
             ],
-            'page_info' => [
-                'page' => 1,
-                'total_pages' => 2,
-                'items_on_page' => 1,
-                'total_items' => 2,
-            ],
+            'has_next_page' => false,
+            'next_cursor' => null,
         ];
 
         // Create a partial mock of TokensApi that will only mock the getTokenPools method
@@ -245,22 +264,28 @@ class TokensApiTest extends TestCase
             ->setConstructorArgs([$this->createMockClient([])])
             ->onlyMethods(['getTokenPools'])
             ->getMock();
-            
-        // Setup the mock to return our predefined responses
+
+        // Setup the mock to return our predefined responses and verify the
+        // second call carries the cursor from the first response
         $api->expects($this->exactly(2))
             ->method('getTokenPools')
             ->willReturnCallback(function($networkId, $tokenAddress, $options) use ($response1, $response2) {
                 static $callCount = 0;
                 $callCount++;
-                return ($callCount === 1) ? $response1 : $response2;
+                if ($callCount === 1) {
+                    $this->assertArrayNotHasKey('cursor', $options);
+                    return $response1;
+                }
+                $this->assertSame('cursor-page-2', $options['cursor'] ?? null);
+                return $response2;
             });
-        
+
         $poolsCollected = [];
         $totalPages = $api->fetchAllTokenPools(
-            'ethereum', 
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 
+            'ethereum',
+            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
             function ($poolsPage, $page) use (&$poolsCollected) {
-                $poolsCollected = array_merge($poolsCollected, $poolsPage['pools']);
+                $poolsCollected = array_merge($poolsCollected, $poolsPage['results']);
                 // Return false after the first page to stop pagination
                 return $page < 1; // Only continue for the first page (index 0)
             },
@@ -269,26 +294,21 @@ class TokensApiTest extends TestCase
 
         $this->assertEquals(2, $totalPages);
         $this->assertCount(2, $poolsCollected);
-        $this->assertEquals('uniswap-v2-eth-usdt', $poolsCollected[0]['id']);
-        $this->assertEquals('uniswap-v2-eth-dai', $poolsCollected[1]['id']);
+        $this->assertEquals('0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852', $poolsCollected[0]['id']);
+        $this->assertEquals('0xa478c2975ab1ea89e8196811f51a7b7ade33eb11', $poolsCollected[1]['id']);
     }
 
     public function testFetchAllTokenPoolsWithStopCondition(): void
     {
         $response1 = [
-            'pools' => [
+            'results' => [
                 [
-                    'id' => 'uniswap-v2-eth-usdt',
-                    'address' => '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
-                    'name' => 'ETH/USDT',
+                    'id' => '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
+                    'chain' => 'ethereum',
                 ],
             ],
-            'page_info' => [
-                'page' => 0,
-                'total_pages' => 2,
-                'items_on_page' => 1,
-                'total_items' => 2,
-            ],
+            'has_next_page' => true,
+            'next_cursor' => 'cursor-page-2',
         ];
 
         $mockClient = $this->createMockClient([
@@ -296,13 +316,13 @@ class TokensApiTest extends TestCase
         ]);
 
         $api = new TokensApi($mockClient);
-        
+
         $poolsCollected = [];
         $totalPages = $api->fetchAllTokenPools(
-            'ethereum', 
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 
+            'ethereum',
+            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
             function ($poolsPage, $page) use (&$poolsCollected) {
-                $poolsCollected = array_merge($poolsCollected, $poolsPage['pools']);
+                $poolsCollected = array_merge($poolsCollected, $poolsPage['results']);
                 return false; // Stop after first page
             },
             ['limit' => 1]


### PR DESCRIPTION
## Why

The API removed `GET /networks/{network}/tokens/{token_address}/pools`. It now returns HTTP 410 with a `replacement` pointing at `/networks/:network/pools/search`, which gained a `token_address` query parameter that restricts results to pools containing that token on that network.

## What changed

- `TokensApi::getTokenPools()` (and its aliases `listTokenPools()`, `getTokenPairs()`, `listTokenPairs()`) now call `/networks/{network}/pools/search` with `token_address`. Method signatures are unchanged; the response is the cursor-paginated search shape (`results`, `has_next_page`, `next_cursor`) instead of `pools` plus `page_info`.
- Sort fields go through the existing `SearchParams::mapPoolSortField` helper (the search endpoint rejects legacy sort values with HTTP 400). The `page` option is accepted but ignored; pass `cursor` from a response's `next_cursor` to page. `fetchAllTokenPools()` follows `next_cursor` internally instead of incrementing `page`.
- The `address` (pair filter) and `reorder` (pair-perspective flip) options are deprecated and no longer sent: the search endpoint has no equivalent for either. Repeating `token_address` does not act as a pair filter; the API uses only one of the values (not guaranteed by order). README and the basic_usage example show the client-side pair filter instead.
- Docblocks call out that the filter is network-scoped only: the cross-network `/pools/search` accepts `token_address` but silently ignores it. A bogus address returns an empty result set, not an error.
- CHANGELOG entry added, `Client::VERSION` bumped to 1.5.0.

## Verification

All checked live against api.dexpaprika.com before pushing:

- The old endpoint returns `{"code":410,"message":"endpoint removed","replacement":"/networks/:network/pools/search"}`.
- `GET /networks/ethereum/pools/search?token_address=0xc02aaa...756cc2&limit=3` returns 3 pools, every one containing WETH, with `has_next_page`/`next_cursor` and default `order_by=volume_usd_24h`.
- Unit suite: 106 tests, 353 assertions, all green. Includes the new `testGetTokenPoolsUsesPoolSearchEndpoint` (asserts the exact wire path and params, and that `page`/`address`/`reorder` are dropped) and the cursor-following `testFetchAllTokenPools`.
- Live integration test `testGetTokenPools` (run with `DEXPAPRIKA_RUN_INTEGRATION_TESTS=1`) passes: every returned pool contains WETH and the cursor advances to a different page. The other integration tests in that file fail for pre-existing reasons unrelated to this change (they still call the long-removed global `/pools`, expect a `token` envelope from `getTokenDetails`, and call a `setTransformResponses()` method that never existed); happy to clean those up in a follow-up.

