### PR TITLE
README: the install command used a placeholder vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The `page` option is still accepted for backward compatibility but is ignored.
 Install via Composer:
 
 ```bash
-composer require your-vendor/dexpaprika-sdk-php
+composer require coinpaprika/dexpaprika-sdk
 ```
 
 ## Basic Usage


### PR DESCRIPTION
The very first command in the README cannot work:

```
composer require your-vendor/dexpaprika-sdk-php
```

`your-vendor` is a placeholder and the package name is wrong. The package is published on Packagist as **`coinpaprika/dexpaprika-sdk`**, which `composer.json` has declared all along, so the README was the only thing out of step.

Verified against Packagist before changing.

Found by the ecosystem drift audit.

https://claude.ai/code/session_01CjkiGV3q4pN7gUAR8vWRW7
