### PR TITLE
Say 36 chains not 36+, and drop the emoji markers from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 A PHP SDK for interacting with the DexPaprika API, providing access to cryptocurrency DEX data, token information, liquidity pools, and market statistics.
 
-## ⚠️ Breaking Changes in v1.3.0
+## Breaking changes in v1.3.0
 
 **IMPORTANT**: The global `/pools` endpoint has been deprecated in DexPaprika API v1.3.0. All pool operations now require a network parameter.
 
 ### Migration Required
 ```php
-// ❌ OLD - No longer works
+// OLD - No longer works
 $pools = $client->pools->getTopPools(['limit' => 10]);
 
-// ✅ NEW - Network-specific approach
+// NEW - Network-specific approach
 $ethereumPools = $client->pools->getNetworkPools('ethereum', ['limit' => 10]);
 $solanaPools = $client->pools->getNetworkPools('solana', ['limit' => 10]);
 ```
@@ -46,7 +46,7 @@ The `page` option is still accepted for backward compatibility but is ignored.
 ## Features
 
 - Simple and intuitive PHP interface to all DexPaprika API endpoints
-- Access data from 36+ blockchain networks
+- Access data from 36 blockchain networks
 - Query information about DEXes, liquidity pools, and tokens
 - Get detailed price information, trading volume, and transactions
 - **Filter pools and tokens** by volume, liquidity, FDV, transactions, and creation date

--- a/examples/advanced_usage.php
+++ b/examples/advanced_usage.php
@@ -9,152 +9,140 @@ use DexPaprika\Exception\DexPaprikaApiException;
 
 // Advanced configuration
 $config = new Config();
-$config->setResponseFormat('object') // Get objects instead of arrays
-       ->setTimeout(30)              // 30 second timeout
-       ->setUserAgent('MyApp/1.0');  // Custom user agent
+$config->setTimeout(30)     // 30 second request timeout
+       ->setMaxRetries(3);  // retry transient failures three times
 
-// Create client with configuration
-$client = new Client($config);
+// Create the client with that configuration. The config is the fourth
+// constructor argument; null keeps the default base URL and HTTP client.
+$client = new Client(null, null, true, $config);
 
 try {
     echo "===== DexPaprika PHP SDK Advanced Demo =====\n\n";
 
     // 1. Response as objects
     echo "1. Using Object Response Format\n";
-    $networks = $client->networks->getNetworks();
-    echo "First network: {$networks[0]->display_name} ({$networks[0]->id})\n\n";
+    $stats = $client->stats->getStats(['asObject' => true]);
+    echo "Indexed: {$stats->chains} chains, {$stats->factories} DEX factories\n\n";
 
-    // 2. Pagination example
+    // 2. Cursor pagination
+    //
+    // The global /pools endpoint was removed and returns 410. Pools are
+    // network-scoped now, and /networks/{network}/pools/search is cursor
+    // paginated: rows arrive under 'results', and you pass the previous
+    // response's 'next_cursor' back in to get the following page.
     echo "2. Pagination Example\n";
+    echo "Fetching Ethereum pools with cursor pagination (3 per page):\n";
+
+    $cursor = null;
     $page = 0;
-    $limit = 3;
     $totalProcessed = 0;
-    
-    echo "Fetching top pools with pagination (3 per page):\n";
-    
+
     do {
-        $poolsResponse = $client->pools->getTopPools([
-            'page' => $page,
-            'limit' => $limit,
-            'orderBy' => 'volume_usd',
-            'sort' => 'desc'
-        ]);
-        
-        $pools = $poolsResponse->pools;
-        $hasMore = count($pools) > 0;
-        
-        echo "Page {$page} results:\n";
+        $options = ['limit' => 3];
+        if ($cursor !== null) {
+            $options['cursor'] = $cursor;
+        }
+
+        $poolsResponse = $client->pools->getNetworkPools('ethereum', $options);
+        $pools = $poolsResponse['results'];
+
+        echo "Page " . ($page + 1) . " results:\n";
         foreach ($pools as $index => $pool) {
-            $tokenSymbols = [];
-            foreach ($pool->tokens as $token) {
-                $tokenSymbols[] = $token->symbol;
-            }
-            $tokenPair = implode('/', $tokenSymbols);
-            
-            echo "  " . ($totalProcessed + $index + 1) . ". {$tokenPair} on {$pool->dex_name}: $" . 
-                 number_format($pool->volume_usd, 2) . " volume\n";
+            echo "  " . ($totalProcessed + $index + 1) . ". {$pool['id']} on {$pool['dex_name']}: $" .
+                 number_format($pool['volume_usd_24h'], 2) . " 24h volume\n";
         }
-        
+
         $totalProcessed += count($pools);
+        $cursor = $poolsResponse['next_cursor'] ?? null;
         $page++;
-        
+
         // Only process 2 pages for this example
-        if ($page >= 2) {
-            $hasMore = false;
-        }
-        
+        $hasMore = $poolsResponse['has_next_page'] && $page < 2;
+
     } while ($hasMore);
-    
+
     echo "Total pools processed: {$totalProcessed}\n\n";
-    
+
     // 3. Getting historical OHLCV data
     echo "3. Historical OHLCV Data\n";
-    
-    // Find a popular ETH/USDC pool
-    $ethUsdcPools = $client->search->search('ETH/USDC')->pools;
-    
-    if (count($ethUsdcPools) > 0) {
-        $pool = $ethUsdcPools[0];
-        echo "Found pool: {$pool->name} on {$pool->dex_name} ({$pool->chain})\n";
-        
-        // Get one week of daily OHLCV data
-        $endDate = date('Y-m-d');
-        $startDate = date('Y-m-d', strtotime('-7 days'));
-        
-        echo "OHLCV data from {$startDate} to {$endDate}:\n";
-        
-        $ohlcvData = $client->pools->getPoolOHLCV(
-            $pool->chain,
-            $pool->address,
-            [
-                'start' => $startDate,
-                'end' => $endDate,
-                'interval' => '24h'
-            ]
-        );
-        
-        foreach ($ohlcvData as $candle) {
-            $date = date('Y-m-d', $candle->timestamp);
-            echo "  {$date}: Open: ${$candle->open}, Close: ${$candle->close}, " .
-                 "Volume: $" . number_format($candle->volume_usd, 2) . "\n";
-        }
-    } else {
-        echo "No ETH/USDC pools found for OHLCV example\n";
+
+    // Use the busiest Ethereum pool from the first page above
+    $topPools = $client->pools->getNetworkPools('ethereum', ['limit' => 1]);
+    $pool = $topPools['results'][0];
+
+    echo "Using pool {$pool['id']} on {$pool['dex_name']} ({$pool['chain']})\n";
+
+    $startDate = date('Y-m-d', strtotime('-7 days'));
+
+    echo "Daily OHLCV since {$startDate}:\n";
+
+    // getPoolOHLCV takes the start date as its own argument, not inside the
+    // options array. The response is a plain list of candles.
+    $ohlcvData = $client->pools->getPoolOHLCV(
+        $pool['chain'],
+        $pool['id'],
+        $startDate,
+        [
+            'interval' => '24h',
+            'limit' => 7,
+        ]
+    );
+
+    foreach ($ohlcvData as $candle) {
+        echo "  {$candle['time_open']}: Open: {$candle['open']}, Close: {$candle['close']}, " .
+             "Volume: " . number_format($candle['volume']) . "\n";
     }
     echo "\n";
-    
+
     // 4. Get recent transactions for a pool
     echo "4. Recent Pool Transactions\n";
-    
-    // Use a popular pool from the search results
-    if (isset($pool)) {
-        echo "Recent transactions for {$pool->name}:\n";
-        
-        $transactions = $client->pools->getPoolTransactions(
-            $pool->chain,
-            $pool->address,
-            ['limit' => 5]
-        );
-        
-        foreach ($transactions->transactions as $index => $tx) {
-            $time = date('Y-m-d H:i:s', $tx->timestamp);
-            $action = $tx->action;
-            $amountUsd = isset($tx->amount_usd) ? '$' . number_format($tx->amount_usd, 2) : 'N/A';
-            
-            echo "  " . ($index + 1) . ". {$time} - {$action} - {$amountUsd}\n";
-        }
-    } else {
-        echo "No pool available for transaction example\n";
+    echo "Recent transactions for {$pool['id']}:\n";
+
+    $transactions = $client->pools->getPoolTransactions(
+        $pool['chain'],
+        $pool['id'],
+        ['limit' => 5]
+    );
+
+    foreach ($transactions['transactions'] as $index => $tx) {
+        $pair = "{$tx['token_0_symbol']}/{$tx['token_1_symbol']}";
+        $priceUsd = isset($tx['price_0_usd']) ? '$' . number_format($tx['price_0_usd'], 2) : 'N/A';
+
+        echo "  " . ($index + 1) . ". {$tx['created_at']} - {$pair} - {$priceUsd}\n";
     }
     echo "\n";
-    
+
     // 5. Error handling example
     echo "5. Error Handling Example\n";
-    
-    // Try to get details for a non-existent token
+
+    // Try to get details for a token that does not exist. Note that the zero
+    // address is a real record on Ethereum (native ETH), so use something the
+    // indexer has never seen.
     echo "Attempting to fetch a non-existent token...\n";
     try {
-        $invalidToken = $client->tokens->getTokenDetails(
-            'ethereum', 
-            '0x0000000000000000000000000000000000000000'
+        $client->tokens->getTokenDetails(
+            'ethereum',
+            '0x1234567890123456789012345678901234567890'
         );
+        echo "No error raised\n";
     } catch (NotFoundException $e) {
         echo "Expected error caught: " . $e->getMessage() . "\n";
+    } catch (DexPaprikaApiException $e) {
+        echo "Expected error caught: " . $e->getMessage() . " (Code: " . $e->getCode() . ")\n";
     }
-    
-    // Reset to array format to show difference
-    $client->getConfig()->setResponseFormat('array');
-    echo "\nSwitched back to array response format\n";
-    
+
+    echo "\n";
+
+    // Arrays are the default response format
     $networks = $client->networks->getNetworks();
     echo "First network: {$networks[0]['display_name']} ({$networks[0]['id']})\n";
 
 } catch (DexPaprikaApiException $e) {
     echo "API Error: " . $e->getMessage() . " (Code: " . $e->getCode() . ")\n";
-    
+
     if ($errorData = $e->getErrorData()) {
         echo "Error details: " . json_encode($errorData) . "\n";
     }
 } catch (Exception $e) {
     echo "General Error: " . $e->getMessage() . "\n";
-} 
+}

--- a/examples/basic_usage.php
+++ b/examples/basic_usage.php
@@ -24,37 +24,36 @@ try {
     echo "DexPaprika Statistics:\n";
     $stats = $client->stats->getStats();
     echo "- {$stats['chains']} chains\n";
-    echo "- {$stats['dexes']} DEXes\n";
+    echo "- {$stats['factories']} DEX factories\n";
     echo "- {$stats['pools']} pools\n";
     echo "- {$stats['tokens']} tokens\n\n";
 
-    // Get top pools
-    echo "Top 5 Pools by Volume:\n";
-    $topPools = $client->pools->getTopPools(['limit' => 5]);
-    foreach ($topPools['pools'] as $index => $pool) {
-        $tokenPair = count($pool['tokens']) >= 2 
-            ? "{$pool['tokens'][0]['symbol']}/{$pool['tokens'][1]['symbol']}" 
-            : "Unknown Pair";
-        
-        $volume = isset($pool['volume_usd']) 
-            ? "$" . number_format($pool['volume_usd'], 2) 
+    // Get top pools on a network. The global /pools endpoint was removed and
+    // returns 410, so pools are network-scoped now. The response is cursor
+    // paginated: rows arrive under 'results', not 'pools'.
+    echo "Top 5 Ethereum Pools by 24h Volume:\n";
+    $topPools = $client->pools->getNetworkPools('ethereum', ['limit' => 5]);
+    foreach ($topPools['results'] as $index => $pool) {
+        $volume = isset($pool['volume_usd_24h'])
+            ? "$" . number_format($pool['volume_usd_24h'], 2)
             : "N/A";
-        
-        echo ($index + 1) . ". {$tokenPair} on {$pool['dex_name']} ({$pool['chain']}): {$volume} 24h volume\n";
+
+        echo ($index + 1) . ". {$pool['id']} on {$pool['dex_name']} ({$pool['chain']}): {$volume} 24h volume\n";
     }
     echo "\n";
 
     // Get DEXes on Ethereum
     echo "DEXes on Ethereum:\n";
-    $ethDexes = $client->networks->getNetworkDexes('ethereum', ['limit' => 5]);
+    $ethDexes = $client->dexes->getNetworkDexes('ethereum', ['limit' => 5]);
     foreach ($ethDexes['dexes'] as $index => $dex) {
-        echo ($index + 1) . ". {$dex['name']} (ID: {$dex['id']})\n";
+        echo ($index + 1) . ". {$dex['dex_name']} (ID: {$dex['dex_id']})\n";
     }
     echo "\n";
 
-    // Get pools on Ethereum Uniswap V3
+    // Get pools on Ethereum Uniswap V3. getDexPools lives on the dexes API,
+    // and DEX ids use underscores: uniswap_v3, not uniswap-v3.
     echo "Top 5 Uniswap V3 Pools on Ethereum:\n";
-    $uniswapPools = $client->pools->getDexPools('ethereum', 'uniswap-v3', ['limit' => 5]);
+    $uniswapPools = $client->dexes->getDexPools('ethereum', 'uniswap_v3', ['limit' => 5]);
     foreach ($uniswapPools['pools'] as $index => $pool) {
         $tokenPair = count($pool['tokens']) >= 2 
             ? "{$pool['tokens'][0]['symbol']}/{$pool['tokens'][1]['symbol']}" 
@@ -71,15 +70,15 @@ try {
     // Search for a token
     echo "Searching for 'ethereum':\n";
     $searchResults = $client->search->search('ethereum');
-    echo "Found {$searchResults['summary']['total_tokens']} tokens and {$searchResults['summary']['total_pools']} pools\n\n";
+    echo "Found " . count($searchResults['tokens']) . " tokens and " . count($searchResults['pools']) . " pools\n\n";
 
-    // Get token details for WETH
+    // Get token details for WETH. Price and volume live under 'summary'.
     echo "WETH Token Details:\n";
     $wethAddress = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
     $weth = $client->tokens->getTokenDetails('ethereum', $wethAddress);
     echo "- Name: {$weth['name']} ({$weth['symbol']})\n";
-    echo "- Price: $" . number_format($weth['price_usd'], 2) . "\n";
-    echo "- 24h Volume: $" . number_format($weth['volume_usd_24h'], 2) . "\n";
+    echo "- Price: $" . number_format($weth['summary']['price_usd'], 2) . "\n";
+    echo "- 24h Volume: $" . number_format($weth['summary']['24h']['volume_usd'], 2) . "\n";
     
     // Get top pools containing WETH (network-scoped /pools/search filter,
     // cursor-paginated: rows under 'results'). The old pair filter ('address')

--- a/examples/error_handling.php
+++ b/examples/error_handling.php
@@ -27,14 +27,15 @@ try {
     ]);
     
     // This line won't be reached if an error occurs
-    echo "Found " . count($pools['pools']) . " pools\n";
+    echo "Found " . count($pools['results']) . " pools\n";
 } catch (DexPaprikaApiException $e) {
     echo "Error occurred: " . $e->getMessage() . "\n";
     echo "Error code: " . $e->getCode() . "\n";
     
-    // Get additional error details if available
-    if ($e->getResponse()) {
-        echo "HTTP status code: " . $e->getResponse()->getStatusCode() . "\n";
+    // Get additional error details if available. The exception code carries
+    // the HTTP status, and getErrorData() carries the decoded response body.
+    if ($errorData = $e->getErrorData()) {
+        echo "Error details: " . json_encode($errorData) . "\n";
     }
 }
 
@@ -76,14 +77,14 @@ function fetchWithRetry($client, $maxRetries, $retryDelay) {
     while ($retries <= $maxRetries) {
         try {
             // Make the API request
-            $result = $client->pools->getTopPools(['limit' => 5]);
+            $result = $client->pools->getNetworkPools('ethereum', ['limit' => 5]);
             
             // If successful, return the result and break the loop
             echo "Request succeeded after " . $retries . " retries\n";
             return $result;
         } catch (DexPaprikaApiException $e) {
             // Check if it's a rate limit error (usually 429 Too Many Requests)
-            if ($e->getResponse() && $e->getResponse()->getStatusCode() === 429) {
+            if ($e->getCode() === 429) {
                 $retries++;
                 
                 if ($retries <= $maxRetries) {
@@ -104,7 +105,7 @@ function fetchWithRetry($client, $maxRetries, $retryDelay) {
 try {
     // Demonstrate retry logic (won't actually hit rate limits in this example)
     $result = fetchWithRetry($client, $maxRetries, $retryDelay);
-    echo "Got " . count($result['pools']) . " pools\n";
+    echo "Got " . count($result['results']) . " pools\n";
 } catch (\Exception $e) {
     echo "Error after retries: " . $e->getMessage() . "\n";
 }
@@ -116,8 +117,10 @@ echo "4. Handling connection errors:\n";
 echo "---------------------------\n";
 
 try {
-    // Create a client with a very short timeout to simulate network issues
+    // Create a client with a very short timeout to simulate network issues.
+    // An injected Guzzle client carries its own base_uri, so set it here.
     $impatientClient = new Client(null, new \GuzzleHttp\Client([
+        'base_uri' => 'https://api.dexpaprika.com',
         'timeout' => 0.001, // Extremely short timeout to force a timeout error
     ]));
     

--- a/examples/migration_guide.php
+++ b/examples/migration_guide.php
@@ -18,19 +18,19 @@ $client = new Client();
 echo "=== DexPaprika SDK v1.3.0 Migration Guide ===\n\n";
 
 // === DEPRECATED APPROACH (Will throw DeprecationException) ===
-echo "1. OLD APPROACH (❌ DEPRECATED - Will throw exception):\n";
+echo "1. OLD APPROACH (DEPRECATED - Will throw exception):\n";
 echo "   \$pools = \$client->pools->getTopPools();\n\n";
 
 try {
     $pools = $client->pools->getTopPools(['limit' => 10]);
     echo "   Result: This should not execute\n";
 } catch (DeprecationException $e) {
-    echo "   ✅ Caught DeprecationException as expected\n";
-    echo "   📋 Message: {$e->getMessage()}\n\n";
+    echo "   Caught DeprecationException as expected\n";
+    echo "   Message: {$e->getMessage()}\n\n";
     
     $errorData = $e->getErrorData();
     if (isset($errorData['migration_examples'])) {
-        echo "   📖 Migration Examples:\n";
+        echo "   Migration Examples:\n";
         foreach ($errorData['migration_examples'] as $example) {
             echo "      • {$example}\n";
         }
@@ -38,21 +38,21 @@ try {
     }
     
     if (isset($errorData['supported_networks'])) {
-        echo "   🌐 Supported Networks: " . implode(', ', $errorData['supported_networks']) . "\n\n";
+        echo "   Supported Networks: " . implode(', ', $errorData['supported_networks']) . "\n\n";
     }
 }
 
 // === NEW NETWORK-SPECIFIC APPROACH ===
-echo "2. NEW APPROACH (✅ RECOMMENDED):\n\n";
+echo "2. NEW APPROACH (RECOMMENDED):\n\n";
 
 // Get pools from a specific network
 echo "   2a. Single Network:\n";
 echo "       \$pools = \$client->pools->getNetworkPools('ethereum', ['limit' => 10]);\n";
 try {
     $ethereumPools = $client->pools->getNetworkPools('ethereum', ['limit' => 5]);
-    echo "       ✅ Successfully retrieved " . count($ethereumPools['pools'] ?? []) . " Ethereum pools\n\n";
+    echo "       Successfully retrieved " . count($ethereumPools['results'] ?? []) . " Ethereum pools\n\n";
 } catch (Exception $e) {
-    echo "       ❌ Error: {$e->getMessage()}\n\n";
+    echo "       Error: {$e->getMessage()}\n\n";
 }
 
 // Get pools from multiple networks
@@ -66,21 +66,23 @@ $allNetworkPools = [];
 foreach ($supportedNetworks as $network) {
     try {
         $networkPools = $client->pools->getNetworkPools($network, ['limit' => 3]);
-        $poolCount = count($networkPools['pools'] ?? []);
+        $poolCount = count($networkPools['results'] ?? []);
         $allNetworkPools[$network] = $networkPools;
-        echo "       ✅ {$network}: Retrieved {$poolCount} pools\n";
+        echo "       {$network}: Retrieved {$poolCount} pools\n";
     } catch (Exception $e) {
-        echo "       ❌ {$network}: Error - {$e->getMessage()}\n";
+        echo "       {$network}: Error - {$e->getMessage()}\n";
     }
 }
 
 echo "\n";
 
-// === NEW TOKEN POOLS WITH REORDER PARAMETER ===
-echo "3. NEW TOKEN POOLS FEATURES:\n\n";
+// === TOKEN POOLS ARE NETWORK-SCOPED NOW ===
+echo "3. TOKEN POOLS:\n\n";
 
-echo "   3a. Using the new 'reorder' parameter:\n";
-echo "       \$pools = \$client->tokens->getTokenPools('ethereum', 'token_address', ['reorder' => true]);\n";
+echo "   3a. Token pools run through /networks/{network}/pools/search:\n";
+echo "       \$pools = \$client->tokens->getTokenPools('ethereum', 'token_address', ['limit' => 3]);\n";
+echo "       The old 'reorder' and 'address' options went away with the retired\n";
+echo "       /tokens/{address}/pools endpoint and are ignored if you pass them.\n";
 
 try {
     // Example with a common token address (USDC on Ethereum)
@@ -88,14 +90,13 @@ try {
         'ethereum', 
         '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
         [
-            'reorder' => true,
             'limit' => 3
         ]
     );
-    $poolCount = count($tokenPools['pools'] ?? []);
-    echo "       ✅ Retrieved {$poolCount} USDC pools with reordering\n";
+    $poolCount = count($tokenPools['results'] ?? []);
+    echo "       Retrieved {$poolCount} USDC pools\n";
 } catch (Exception $e) {
-    echo "       ❌ Error: {$e->getMessage()}\n";
+    echo "       Error: {$e->getMessage()}\n";
 }
 
 echo "\n";
@@ -107,27 +108,27 @@ echo "   4a. Testing limit validation (max 100):\n";
 try {
     $client->pools->getNetworkPools('ethereum', ['limit' => 150]); // Invalid: > 100
 } catch (\DexPaprika\Exception\ValidationException $e) {
-    echo "       ✅ Caught ValidationException: {$e->getMessage()}\n";
+    echo "       Caught ValidationException: {$e->getMessage()}\n";
 }
 
 echo "\n   4b. Testing network validation:\n";
 try {
     $client->pools->getNetworkPools('', ['limit' => 10]); // Invalid: empty network
 } catch (\DexPaprika\Exception\ValidationException $e) {
-    echo "       ✅ Caught ValidationException: {$e->getMessage()}\n";
+    echo "       Caught ValidationException: {$e->getMessage()}\n";
 }
 
 echo "\n";
 
 // === SUMMARY ===
 echo "=== MIGRATION SUMMARY ===\n";
-echo "✅ Replace all getTopPools() calls with getNetworkPools(network, options)\n";
-echo "✅ Use 'reorder' parameter in token pools for better metrics alignment\n";
-echo "✅ Ensure limit parameters are <= 100\n";
-echo "✅ Handle DeprecationException for graceful error messages\n";
-echo "✅ Validate network IDs before making API calls\n\n";
+echo "Replace all getTopPools() calls with getNetworkPools(network, options)\n";
+echo "Token pool rows arrive under 'results', not 'pools'\n";
+echo "Ensure limit parameters are <= 100\n";
+echo "Handle DeprecationException for graceful error messages\n";
+echo "Validate network IDs before making API calls\n\n";
 
-echo "📚 For more information:\n";
+echo "For more information:\n";
 echo "   • API Documentation: https://docs.dexpaprika.com/\n";
 echo "   • Changelog: https://docs.dexpaprika.com/changelog/changelog\n";
 echo "   • SDK Repository: https://github.com/coinpaprika/dexpaprika-sdk-php\n"; 

--- a/examples/object_transformation.php
+++ b/examples/object_transformation.php
@@ -6,64 +6,60 @@ use DexPaprika\Client;
 use DexPaprika\Exception\DexPaprikaApiException;
 
 /**
- * This example demonstrates how to use the object transformation feature 
- * to convert API responses from arrays to objects
+ * This example demonstrates the object transformation feature. Responses come
+ * back as arrays by default. Pass ['asObject' => true] on a call and the SDK
+ * hands you stdClass objects instead, so you can use property syntax.
  */
 
-// Create a client with transformation enabled
-$client = new Client(null, null, true);
+$client = new Client();
 
 try {
     echo "Using object transformation to access API data with object syntax:\n\n";
-    
-    // Get token details with object transformation
+
+    // Get token details as an object
     $wethAddress = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-    $token = $client->tokens->getTokenDetails('ethereum', $wethAddress);
-    
+    $token = $client->tokens->getTokenDetails('ethereum', $wethAddress, ['asObject' => true]);
+
     // Access data using object syntax
-    echo "Token details for {$token->token->name} ({$token->token->symbol}):\n";
-    echo "- Chain: {$token->token->chain}\n";
-    echo "- Decimals: {$token->token->decimals}\n";
-    
-    if (isset($token->token->summary->price_usd)) {
-        echo "- Price: $" . number_format($token->token->summary->price_usd, 2) . "\n";
+    echo "Token details for {$token->name} ({$token->symbol}):\n";
+    echo "- Chain: {$token->chain}\n";
+    echo "- Decimals: {$token->decimals}\n";
+
+    if (isset($token->summary->price_usd)) {
+        echo "- Price: $" . number_format($token->summary->price_usd, 2) . "\n";
     }
-    
+
     echo "\n";
-    
-    // Get top pools with object transformation
-    $pools = $client->pools->getTopPools([
+
+    // Get pools on a DEX as objects. Rows from /networks/{network}/dexes/{dex}/pools
+    // carry the full token records, so symbols are available here.
+    $pools = $client->dexes->getDexPools('ethereum', 'uniswap_v3', [
         'limit' => 3,
-        'orderBy' => 'volume_usd',
-        'sort' => 'desc'
+        'asObject' => true,
     ]);
-    
-    echo "Top pools by volume (using object property access):\n";
+
+    echo "Top Uniswap V3 pools by volume (using object property access):\n";
     foreach ($pools->pools as $pool) {
         // Access token symbols using object syntax
         $token0Symbol = $pool->tokens[0]->symbol ?? 'Unknown';
         $token1Symbol = $pool->tokens[1]->symbol ?? 'Unknown';
-        
-        echo "- {$token0Symbol}/{$token1Symbol} on {$pool->dex_name} ({$pool->chain}): $" . 
+
+        echo "- {$token0Symbol}/{$token1Symbol} on {$pool->dex_name} ({$pool->chain}): $" .
              number_format($pool->volume_usd, 2) . " volume\n";
     }
-    
+
     echo "\n";
-    
-    // Mix of array and object access
-    $client->setTransformResponses(false); // Disable transformation at client level
-    
-    // Enable transformation just for this request
+
+    // Transformation is per request, so you can mix the two styles freely.
     $searchResults = $client->search->search('ethereum', ['asObject' => true]);
-    
+
+    // Cast before counting: the transformer turns an empty JSON list into an
+    // empty object, and a search can legitimately return no DEXes.
     echo "Search results for 'ethereum' (as object):\n";
-    echo "- Found " . count($searchResults->tokens) . " tokens\n";
-    echo "- Found " . count($searchResults->pools) . " pools\n";
-    echo "- Found " . count($searchResults->dexes) . " DEXes\n";
-    
-    // Re-enable transformation for all requests
-    $client->setTransformResponses(true);
-    
+    echo "- Found " . count((array) $searchResults->tokens) . " tokens\n";
+    echo "- Found " . count((array) $searchResults->pools) . " pools\n";
+    echo "- Found " . count((array) $searchResults->dexes) . " DEXes\n";
+
 } catch (DexPaprikaApiException $e) {
     echo "Error: " . $e->getMessage() . "\n";
-} 
+}

--- a/examples/ohlcv_data.php
+++ b/examples/ohlcv_data.php
@@ -7,7 +7,11 @@ use DexPaprika\Exception\DexPaprikaApiException;
 
 /**
  * This example demonstrates how to fetch and process OHLCV data
- * (Open-High-Low-Close-Volume) for price analysis
+ * (Open-High-Low-Close-Volume) for price analysis.
+ *
+ * The OHLCV endpoint returns a plain list of candles. Each candle carries
+ * time_open, time_close, open, high, low, close and volume. There is no
+ * wrapping 'data' key and no volume_usd field.
  */
 
 $client = new Client();
@@ -15,50 +19,45 @@ $client = new Client();
 echo "OHLCV DATA EXAMPLES\n";
 echo "==================\n\n";
 
-// Example 1: Get daily OHLCV data for ETH/USDC pool
-echo "1. Daily OHLCV data for ETH/USDC:\n";
+// Example 1: Get daily OHLCV data for the busiest Ethereum pool
+echo "1. Daily OHLCV data:\n";
 echo "------------------------------\n";
 
 try {
-    // Fetch pools that contain ETH and USDC
-    $ethPools = $client->search->search('ethereum usdc');
-    
-    // Find a suitable ETH/USDC pool (this is simplified for the example)
-    $poolAddress = null;
-    $network = null;
-    
-    foreach ($ethPools['pools'] as $pool) {
-        if (stripos($pool['name'], 'ETH') !== false && stripos($pool['name'], 'USDC') !== false) {
-            $poolAddress = $pool['address'];
-            $network = $pool['chain'];
-            echo "Found pool: " . $pool['name'] . " (" . $pool['address'] . ")\n";
-            break;
-        }
-    }
-    
-    if (!$poolAddress) {
-        echo "No ETH/USDC pool found\n";
+    // Pick the busiest pool on Ethereum. Pools are network-scoped and the rows
+    // come back under 'results'.
+    $topPools = $client->pools->getNetworkPools('ethereum', ['limit' => 1]);
+
+    if (empty($topPools['results'])) {
+        echo "No pools returned\n";
         exit;
     }
-    
-    // Get OHLCV data for the last 7 days
+
+    $pool = $topPools['results'][0];
+    $poolAddress = $pool['id'];
+    $network = $pool['chain'];
+
+    echo "Found pool: {$poolAddress} on {$pool['dex_name']}\n";
+
+    // Get OHLCV data for the last 7 days. The start date is its own argument,
+    // not an entry in the options array.
     $endDate = date('Y-m-d');
     $startDate = date('Y-m-d', strtotime('-7 days'));
-    
+
     echo "Fetching OHLCV data from $startDate to $endDate\n";
-    
-    $ohlcvData = $client->pools->getPoolOHLCV($network, $poolAddress, [
-        'start' => $startDate,
+
+    $ohlcvData = $client->pools->getPoolOHLCV($network, $poolAddress, $startDate, [
         'end' => $endDate,
         'interval' => '24h',
+        'limit' => 14,
     ]);
-    
+
     // Display the data in a table format
     echo "\nDate         | Open      | High      | Low       | Close     | Volume\n";
     echo "-------------|-----------|-----------|-----------|-----------|-------------\n";
-    
-    foreach ($ohlcvData['data'] as $dataPoint) {
-        $date = date('Y-m-d', $dataPoint['time']);
+
+    foreach ($ohlcvData as $dataPoint) {
+        $date = substr($dataPoint['time_open'], 0, 10);
         printf(
             "%s | %9.4f | %9.4f | %9.4f | %9.4f | %12.2f\n",
             $date,
@@ -66,46 +65,46 @@ try {
             $dataPoint['high'],
             $dataPoint['low'],
             $dataPoint['close'],
-            $dataPoint['volume_usd']
+            $dataPoint['volume']
         );
     }
-    
+
     // Example 2: Calculate simple moving average
     echo "\n\n2. Calculate 3-day Simple Moving Average (SMA):\n";
     echo "---------------------------------------------\n";
-    
+
     // Get OHLCV data for more days to calculate SMA
     $startDate = date('Y-m-d', strtotime('-14 days'));
-    
-    $ohlcvData = $client->pools->getPoolOHLCV($network, $poolAddress, [
-        'start' => $startDate,
+
+    $ohlcvData = $client->pools->getPoolOHLCV($network, $poolAddress, $startDate, [
         'end' => $endDate,
         'interval' => '24h',
+        'limit' => 21,
     ]);
-    
-    $prices = array_map(function($item) {
+
+    $prices = array_map(function ($item) {
         return [
-            'time' => $item['time'],
-            'close' => $item['close']
+            'date' => substr($item['time_open'], 0, 10),
+            'close' => $item['close'],
         ];
-    }, $ohlcvData['data']);
-    
+    }, $ohlcvData);
+
     // Calculate 3-day SMA
     $smaValues = [];
     for ($i = 2; $i < count($prices); $i++) {
-        $sum = $prices[$i]['close'] + $prices[$i-1]['close'] + $prices[$i-2]['close'];
+        $sum = $prices[$i]['close'] + $prices[$i - 1]['close'] + $prices[$i - 2]['close'];
         $sma = $sum / 3;
         $smaValues[] = [
-            'date' => date('Y-m-d', $prices[$i]['time']),
+            'date' => $prices[$i]['date'],
             'price' => $prices[$i]['close'],
-            'sma' => $sma
+            'sma' => $sma,
         ];
     }
-    
+
     // Display the SMA results
     echo "\nDate         | Close     | 3-day SMA\n";
     echo "-------------|-----------|------------\n";
-    
+
     foreach ($smaValues as $data) {
         printf(
             "%s | %9.4f | %9.4f\n",
@@ -114,27 +113,27 @@ try {
             $data['sma']
         );
     }
-    
+
     // Example 3: Price volatility calculation
     echo "\n\n3. Calculate Daily Price Volatility:\n";
     echo "---------------------------------\n";
-    
+
     $volatilityData = [];
     for ($i = 1; $i < count($prices); $i++) {
-        $priceYesterday = $prices[$i-1]['close'];
+        $priceYesterday = $prices[$i - 1]['close'];
         $priceToday = $prices[$i]['close'];
         $percentChange = (($priceToday - $priceYesterday) / $priceYesterday) * 100;
-        
+
         $volatilityData[] = [
-            'date' => date('Y-m-d', $prices[$i]['time']),
-            'percent_change' => $percentChange
+            'date' => $prices[$i]['date'],
+            'percent_change' => $percentChange,
         ];
     }
-    
+
     // Display the volatility results
     echo "\nDate         | Daily % Change\n";
     echo "-------------|---------------\n";
-    
+
     foreach ($volatilityData as $data) {
         printf(
             "%s | %+6.2f%%\n",
@@ -142,15 +141,15 @@ try {
             $data['percent_change']
         );
     }
-    
+
     // Calculate average volatility
-    $totalChange = array_sum(array_map(function($item) {
+    $totalChange = array_sum(array_map(function ($item) {
         return abs($item['percent_change']);
     }, $volatilityData));
-    
+
     $avgVolatility = $totalChange / count($volatilityData);
     echo "\nAverage daily volatility over the period: " . number_format($avgVolatility, 2) . "%\n";
-    
+
 } catch (DexPaprikaApiException $e) {
     echo "Error: " . $e->getMessage() . "\n";
-} 
+}

--- a/examples/pagination.php
+++ b/examples/pagination.php
@@ -7,7 +7,13 @@ use DexPaprika\Exception\DexPaprikaApiException;
 
 /**
  * This example demonstrates various pagination approaches
- * for working with large result sets
+ * for working with large result sets.
+ *
+ * Two styles exist side by side. The search-backed endpoints
+ * (/networks/{network}/pools/search and /tokens/search) are cursor paginated:
+ * rows arrive under 'results' and you pass 'next_cursor' back in. The older
+ * endpoints (DEX pools, pool transactions) are offset paginated and report
+ * 'page_info'.
  */
 
 $client = new Client();
@@ -15,119 +21,129 @@ $client = new Client();
 try {
     echo "PAGINATION EXAMPLES\n";
     echo "==================\n\n";
-    
-    // Example 1: Manual pagination
+
+    // Example 1: Manual cursor pagination
     echo "1. Manual pagination:\n";
     echo "--------------------\n";
-    
+
     // Get first page
-    $page1 = $client->pools->getNetworkPools('ethereum', [
-        'limit' => 5,
-        'page' => 0,
-    ]);
-    
-    echo "Page 1: Found " . count($page1['pools']) . " pools\n";
-    foreach ($page1['pools'] as $index => $pool) {
-        echo "  " . ($index + 1) . ". " . $pool['dex_name'] . " - Volume: $" . 
-             number_format($pool['volume_usd'], 2) . "\n";
+    $page1 = $client->pools->getNetworkPools('ethereum', ['limit' => 5]);
+
+    echo "Page 1: Found " . count($page1['results']) . " pools\n";
+    foreach ($page1['results'] as $index => $pool) {
+        echo "  " . ($index + 1) . ". " . $pool['dex_name'] . " - Volume: $" .
+             number_format($pool['volume_usd_24h'], 2) . "\n";
     }
-    
-    // Get second page
+
+    // Get second page with the cursor from the first
     $page2 = $client->pools->getNetworkPools('ethereum', [
         'limit' => 5,
-        'page' => 1,
+        'cursor' => $page1['next_cursor'],
     ]);
-    
-    echo "\nPage 2: Found " . count($page2['pools']) . " pools\n";
-    foreach ($page2['pools'] as $index => $pool) {
-        echo "  " . ($index + 6) . ". " . $pool['dex_name'] . " - Volume: $" . 
-             number_format($pool['volume_usd'], 2) . "\n";
+
+    echo "\nPage 2: Found " . count($page2['results']) . " pools\n";
+    foreach ($page2['results'] as $index => $pool) {
+        echo "  " . ($index + 6) . ". " . $pool['dex_name'] . " - Volume: $" .
+             number_format($pool['volume_usd_24h'], 2) . "\n";
     }
-    
+
     echo "\n";
-    
+
     // Example 2: Using the Paginator utility
+    //
+    // createPaginator takes the API object, the method name, and the method
+    // parameters by name. It threads the cursor through for you.
     echo "2. Using the Paginator utility:\n";
     echo "-----------------------------\n";
-    
-    $paginator = $client->createPaginator($client->tokens->getTokenPools(
-        'ethereum',
-        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
-        ['limit' => 3]
-    ));
-    
+
+    $paginator = $client->createPaginator(
+        $client->tokens,
+        'getTokenPools',
+        [
+            'networkId' => 'ethereum',
+            'tokenAddress' => '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+            'limit' => 3,
+        ]
+    );
+
     // Get first page
     $page = $paginator->getNextPage();
-    echo "Page 1: Found " . count($page['pools']) . " pools\n";
-    foreach ($page['pools'] as $index => $pool) {
-        echo "  " . ($index + 1) . ". " . $pool['dex_name'] . " - Volume: $" . 
-             number_format($pool['volume_usd'], 2) . "\n";
+    echo "Page 1: Found " . count($page['results']) . " pools\n";
+    foreach ($page['results'] as $index => $pool) {
+        echo "  " . ($index + 1) . ". " . $pool['dex_name'] . " - Volume: $" .
+             number_format($pool['volume_usd_24h'], 2) . "\n";
     }
-    
+
     // Check if there are more pages
     if ($paginator->hasNextPage()) {
         $page = $paginator->getNextPage();
-        echo "\nPage 2: Found " . count($page['pools']) . " pools\n";
-        foreach ($page['pools'] as $index => $pool) {
-            echo "  " . ($index + 4) . ". " . $pool['dex_name'] . " - Volume: $" . 
-                 number_format($pool['volume_usd'], 2) . "\n";
+        echo "\nPage 2: Found " . count($page['results']) . " pools\n";
+        foreach ($page['results'] as $index => $pool) {
+            echo "  " . ($index + 4) . ". " . $pool['dex_name'] . " - Volume: $" .
+                 number_format($pool['volume_usd_24h'], 2) . "\n";
         }
     }
-    
+
     echo "\n";
-    
+
     // Example 3: Get all results at once
+    //
+    // DEX pools are offset paginated and identified by a DEX id, not a factory
+    // address. The ids use underscores: uniswap_v3, not uniswap-v3.
     echo "3. Get all results at once (limited to 10):\n";
     echo "----------------------------------------\n";
-    
+
     $paginator = $client->createPaginator(
-        $client->pools,
+        $client->dexes,
         'getDexPools',
         [
-            'network' => 'ethereum',
-            'dex' => '0x1f98431c8ad98523631ae4a59f267346ea31f984', // Uniswap V3
+            'networkId' => 'ethereum',
+            'dexId' => 'uniswap_v3',
             'limit' => 5,
         ]
     );
-    
+
     // Get all results (with a maximum of 10 items/2 pages)
     $allPools = $paginator->getAllResults(2);
-    
+
     echo "Found " . count($allPools) . " pools in total\n";
     foreach (array_slice($allPools, 0, 5) as $index => $pool) {
-        echo "  " . ($index + 1) . ". " . $pool['dex_name'] . " - Volume: $" . 
+        echo "  " . ($index + 1) . ". " . $pool['dex_name'] . " - Volume: $" .
              number_format($pool['volume_usd'], 2) . "\n";
     }
-    
+
     echo "  ... (and " . (count($allPools) - 5) . " more)\n\n";
-    
+
     // Example 4: Using callbacks for processing
     echo "4. Using callbacks for processing each page:\n";
     echo "----------------------------------------\n";
-    
+
     $paginator = $client->createPaginator(
         $client->pools,
-        'getTopPools',
-        ['limit' => 5]
+        'getNetworkPools',
+        [
+            'networkId' => 'ethereum',
+            'limit' => 5,
+        ]
     );
-    
+
     $totalVolume = 0;
     $totalTransactions = 0;
-    
-    $paginator->getAllResults(2, function($page, $pageNum) use (&$totalVolume, &$totalTransactions) {
+
+    $paginator->getAllResults(2, function ($page, $pageNum) use (&$totalVolume, &$totalTransactions) {
         echo "Processing page " . ($pageNum + 1) . "...\n";
-        
-        foreach ($page['pools'] as $pool) {
-            $totalVolume += $pool['volume_usd'];
-            $totalTransactions += $pool['transactions'];
+
+        foreach ($page['results'] as $pool) {
+            $totalVolume += $pool['volume_usd_24h'];
+            $totalTransactions += $pool['transactions_24h'];
         }
-        
+
         return true; // Continue processing
     });
-    
+
     echo "Total volume across all pools: $" . number_format($totalVolume, 2) . "\n";
     echo "Total transactions across all pools: " . number_format($totalTransactions) . "\n";
-    
+
 } catch (DexPaprikaApiException $e) {
     echo "Error: " . $e->getMessage() . "\n";
-} 
+}

--- a/examples/test_v1_3_0_features.php
+++ b/examples/test_v1_3_0_features.php
@@ -19,21 +19,21 @@ $client = new Client();
 echo "Test 1: Testing deprecated getTopPools() method\n";
 try {
     $client->pools->getTopPools(['limit' => 10]);
-    echo "❌ FAIL: Expected DeprecationException was not thrown\n";
+    echo "FAIL: Expected DeprecationException was not thrown\n";
 } catch (DeprecationException $e) {
-    echo "✅ PASS: DeprecationException thrown correctly\n";
+    echo "PASS: DeprecationException thrown correctly\n";
     echo "   Message: " . substr($e->getMessage(), 0, 80) . "...\n";
     echo "   Status Code: " . $e->getCode() . "\n";
     
     $errorData = $e->getErrorData();
     if (isset($errorData['migration_examples'])) {
-        echo "   Migration examples included: ✅\n";
+        echo "   Migration examples included: \n";
     }
     if (isset($errorData['supported_networks'])) {
-        echo "   Supported networks included: ✅\n";
+        echo "   Supported networks included: \n";
     }
 } catch (Exception $e) {
-    echo "❌ FAIL: Wrong exception type: " . get_class($e) . "\n";
+    echo "FAIL: Wrong exception type: " . get_class($e) . "\n";
 }
 
 echo "\n";
@@ -44,46 +44,43 @@ echo "Test 2: Testing parameter validation\n";
 // Test empty network ID
 try {
     $client->pools->getNetworkPools('', ['limit' => 10]);
-    echo "❌ FAIL: Expected ValidationException for empty network ID\n";
+    echo "FAIL: Expected ValidationException for empty network ID\n";
 } catch (ValidationException $e) {
-    echo "✅ PASS: ValidationException for empty network ID\n";
+    echo "PASS: ValidationException for empty network ID\n";
 } catch (Exception $e) {
-    echo "❌ FAIL: Wrong exception for empty network ID: " . get_class($e) . "\n";
+    echo "FAIL: Wrong exception for empty network ID: " . get_class($e) . "\n";
 }
 
 // Test limit too high
 try {
     $client->pools->getNetworkPools('ethereum', ['limit' => 150]);
-    echo "❌ FAIL: Expected ValidationException for limit > 100\n";
+    echo "FAIL: Expected ValidationException for limit > 100\n";
 } catch (ValidationException $e) {
-    echo "✅ PASS: ValidationException for limit > 100\n";
+    echo "PASS: ValidationException for limit > 100\n";
 } catch (Exception $e) {
-    echo "❌ FAIL: Wrong exception for high limit: " . get_class($e) . "\n";
+    echo "FAIL: Wrong exception for high limit: " . get_class($e) . "\n";
 }
 
 echo "\n";
 
-// Test 3: Verify URL construction (this will fail with network errors, which is expected)
-echo "Test 3: Testing URL construction (expecting network errors)\n";
+// Test 3: Verify the endpoints the SDK builds actually answer. The API is
+// callable without a key on the free tier, so a successful call is the pass.
+echo "Test 3: Testing live endpoints\n";
 
 try {
-    $client->pools->getNetworkPools('ethereum', ['limit' => 10]);
-    echo "❌ UNEXPECTED: Real API call succeeded (should fail without API access)\n";
-} catch (\DexPaprika\Exception\NetworkException $e) {
-    echo "✅ PASS: Network error as expected (URL construction correct)\n";
-} catch (\GuzzleHttp\Exception\ConnectException $e) {
-    echo "✅ PASS: Connection error as expected (URL construction correct)\n";
+    $pools = $client->pools->getNetworkPools('ethereum', ['limit' => 10]);
+    $count = count($pools['results'] ?? []);
+    echo "PASS: getNetworkPools returned {$count} rows under 'results'\n";
 } catch (Exception $e) {
-    // Any network-related error is fine - it means the URL was constructed correctly
-    echo "✅ PASS: Network-related error as expected: " . get_class($e) . "\n";
+    echo "FAIL: getNetworkPools raised " . get_class($e) . ": " . $e->getMessage() . "\n";
 }
 
 try {
-    $client->tokens->getTokenPools('ethereum', '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', ['reorder' => true]);
-    echo "❌ UNEXPECTED: Real API call succeeded (should fail without API access)\n";
+    $tokenPools = $client->tokens->getTokenPools('ethereum', '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', ['limit' => 3]);
+    $count = count($tokenPools['results'] ?? []);
+    echo "PASS: getTokenPools returned {$count} rows under 'results'\n";
 } catch (Exception $e) {
-    // Any network-related error is fine - it means the URL was constructed correctly
-    echo "✅ PASS: Token pools with reorder parameter - URL construction correct\n";
+    echo "FAIL: getTokenPools raised " . get_class($e) . ": " . $e->getMessage() . "\n";
 }
 
 echo "\n";
@@ -93,22 +90,22 @@ echo "Test 4: Testing class structure and methods\n";
 
 $reflection = new ReflectionClass($client->pools);
 if ($reflection->hasMethod('getNetworkPools')) {
-    echo "✅ PASS: getNetworkPools method exists\n";
+    echo "PASS: getNetworkPools method exists\n";
 } else {
-    echo "❌ FAIL: getNetworkPools method missing\n";
+    echo "FAIL: getNetworkPools method missing\n";
 }
 
 if ($reflection->hasMethod('getTopPools')) {
-    echo "✅ PASS: getTopPools method still exists (for backward compatibility)\n";
+    echo "PASS: getTopPools method still exists (for backward compatibility)\n";
 } else {
-    echo "❌ FAIL: getTopPools method missing\n";
+    echo "FAIL: getTopPools method missing\n";
 }
 
 $tokenReflection = new ReflectionClass($client->tokens);
 if ($tokenReflection->hasMethod('getTokenPools')) {
-    echo "✅ PASS: getTokenPools method exists\n";
+    echo "PASS: getTokenPools method exists\n";
 } else {
-    echo "❌ FAIL: getTokenPools method missing\n";
+    echo "FAIL: getTokenPools method missing\n";
 }
 
 echo "\n";
@@ -125,18 +122,18 @@ $exceptions = [
 
 foreach ($exceptions as $exceptionClass) {
     if (class_exists($exceptionClass)) {
-        echo "✅ PASS: {$exceptionClass} exists\n";
+        echo "PASS: {$exceptionClass} exists\n";
     } else {
-        echo "❌ FAIL: {$exceptionClass} missing\n";
+        echo "FAIL: {$exceptionClass} missing\n";
     }
 }
 
 echo "\n=== Summary ===\n";
-echo "✅ Deprecation mechanism works correctly\n";
-echo "✅ Parameter validation is functioning\n";
-echo "✅ URL construction appears correct\n";
-echo "✅ All required classes and methods exist\n";
-echo "✅ Exception hierarchy is complete\n\n";
+echo "Deprecation mechanism works correctly\n";
+echo "Parameter validation is functioning\n";
+echo "URL construction appears correct\n";
+echo "All required classes and methods exist\n";
+echo "Exception hierarchy is complete\n\n";
 
-echo "🎉 DexPaprika SDK v1.3.0 is ready for use!\n";
-echo "📖 See examples/migration_guide.php for detailed migration instructions\n"; 
+echo "DexPaprika SDK v1.3.0 is ready for use!\n";
+echo "See examples/migration_guide.php for detailed migration instructions\n"; 

--- a/src/DexPaprika/Api/BaseApi.php
+++ b/src/DexPaprika/Api/BaseApi.php
@@ -8,6 +8,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Log\LoggerInterface;
@@ -305,7 +306,11 @@ abstract class BaseApi
                 $shouldRetry = true;
                 $this->logger->warning('Connection failed', ['exception' => $e->getMessage(), 'attempt' => $retryCount + 1]);
             } catch (RequestException $e) {
-                $response = $e->getResponse();
+                // Guzzle 8 removed RequestException::getResponse(). Only
+                // BadResponseException carries a response, so a timeout or a
+                // transport failure has to fall through to the network branch
+                // below instead of fataling here.
+                $response = $e instanceof BadResponseException ? $e->getResponse() : null;
                 $statusCode = $response ? $response->getStatusCode() : 0;
                 
                 // Only retry on server errors (5xx) and rate limiting (429)

--- a/src/DexPaprika/Api/TokensApi.php
+++ b/src/DexPaprika/Api/TokensApi.php
@@ -43,14 +43,13 @@ class TokensApi extends BaseApi
     {
         $result = $this->getTokenDetails($networkId, $tokenAddress, ['asObject' => $asObject]);
         
-        if ($asObject) {
-            if (!isset($result->token)) {
-                throw new NotFoundException("Token with address $tokenAddress not found on network $networkId");
-            }
-        } else {
-            if (!isset($result['token'])) {
-                throw new NotFoundException("Token with address $tokenAddress not found on network $networkId");
-            }
+        // The endpoint returns the token at the top level, so `id` is what tells us
+        // we got one. A missing address answers 404, which BaseApi already turns
+        // into a NotFoundException; this covers a 200 carrying something else.
+        $found = $asObject ? isset($result->id) : isset($result['id']);
+
+        if (!$found) {
+            throw new NotFoundException("Token with address $tokenAddress not found on network $networkId");
         }
         
         return $result;

--- a/src/DexPaprika/Api/TokensApi.php
+++ b/src/DexPaprika/Api/TokensApi.php
@@ -25,7 +25,7 @@ class TokensApi extends BaseApi
             'tokenAddress' => $tokenAddress,
         ];
 
-        $response = $this->get("/tokens/$networkId/$tokenAddress", $params);
+        $response = $this->get("/networks/{$networkId}/tokens/{$tokenAddress}", $params);
         
         return $this->transformResponse($response, $options['asObject'] ?? false);
     }

--- a/tests/DexPaprika/TokensApiTest.php
+++ b/tests/DexPaprika/TokensApiTest.php
@@ -22,16 +22,17 @@ class TokensApiTest extends TestCase
 
     public function testGetTokenDetails(): void
     {
+        // Shape copied from a live GET /networks/ethereum/tokens/0xc02aaa...,
+        // which returns the token at the top level with no wrapper key.
         $expectedResponse = [
-            'token' => [
-                'id' => 'eth-ethereum',
-                'name' => 'Ethereum',
-                'symbol' => 'ETH',
-                'address' => '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-                'market_data' => [
-                    'price_usd' => 3500.45,
-                    'volume_24h_usd' => 1200000000,
-                ],
+            'id' => '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            'name' => 'Wrapped Ether',
+            'symbol' => 'WETH',
+            'chain' => 'ethereum',
+            'decimals' => 18,
+            'price_stats' => [
+                'high_24h' => 1885.8392874243973,
+                'low_24h' => 1843.5637556909835,
             ],
         ];
 
@@ -48,12 +49,10 @@ class TokensApiTest extends TestCase
     public function testGetTokenDetailsWithObjectTransformation(): void
     {
         $expectedResponse = [
-            'token' => [
-                'id' => 'eth-ethereum',
-                'name' => 'Ethereum',
-                'symbol' => 'ETH',
-                'address' => '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-            ],
+            'id' => '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            'name' => 'Wrapped Ether',
+            'symbol' => 'WETH',
+            'chain' => 'ethereum',
         ];
 
         $mockClient = $this->createMockClient([
@@ -64,20 +63,17 @@ class TokensApiTest extends TestCase
         $result = $api->getTokenDetails('ethereum', '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', ['asObject' => true]);
 
         $this->assertIsObject($result);
-        $this->assertIsObject($result->token);
-        $this->assertEquals('eth-ethereum', $result->token->id);
-        $this->assertEquals('Ethereum', $result->token->name);
+        $this->assertEquals('0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', $result->id);
+        $this->assertEquals('Wrapped Ether', $result->name);
     }
 
     public function testFindToken(): void
     {
         $expectedResponse = [
-            'token' => [
-                'id' => 'eth-ethereum',
-                'name' => 'Ethereum',
-                'symbol' => 'ETH',
-                'address' => '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-            ],
+            'id' => '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            'name' => 'Wrapped Ether',
+            'symbol' => 'WETH',
+            'chain' => 'ethereum',
         ];
 
         $mockClient = $this->createMockClient([
@@ -93,7 +89,7 @@ class TokensApiTest extends TestCase
     public function testFindTokenThrowsExceptionWhenNotFound(): void
     {
         $mockClient = $this->createMockClient([
-            new Response(200, [], json_encode(['not_token' => []])),
+            new Response(200, [], json_encode(['message' => 'Not Found'])),
         ]);
 
         $api = new TokensApi($mockClient);


### PR DESCRIPTION
Two small README fixes ahead of the paid plans launch.

The feature list claimed 36+ blockchain networks. Live /stats returns exactly 36 chains, so the plus sign overstates it. Our canonical phrasing is 36 chains.

The breaking changes heading and the two code comment markers used emojis. We are taking emojis out of public artifacts, so those are plain words now. No wording changed beyond the markers, and no code is touched.