### PR TITLE
Add the short price-change windows to pool search sort and filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Short price-change windows on pool search**: `price_change_percentage_6h`, `price_change_percentage_1h` and `price_change_percentage_5m` are now recognised as canonical `sortBy`/`orderBy` values for `PoolsApi::getNetworkPools()` and `PoolsApi::filterPools()`. Previously they fell through to the unknown-field fallback and were sent as `volume_usd_24h`, so a caller asking for the 1h sort got `200` and a full result set ordered by volume.
 - **Price-change bounds on `PoolsApi::filterPools()`**: eight new options, `priceChangePercentage{24h,6h,1h,5m}{Min,Max}`, mapping to `price_change_percentage_{24h,6h,1h,5m}_{min,max}`. `filterPools()` reads named keys, so bounds it does not name cannot be passed at all. The 24h pair is included; the endpoint already accepted it. Bounds are percentages and negative values are the common case: down at least 20 percent in the last hour is `'priceChangePercentage1hMax' => -20`.
+- **24h price-change bounds on `TokensApi::filterTokens()`**: `priceChangePercentage24hMin` and `priceChangePercentage24hMax`, mapping to `price_change_percentage_24h_{min,max}`. `tokens/search` has honoured this pair all along and the SDK had no way to send it.
 
 ### Notes
-- These four windows are pools-only. `tokens/search` returns `400` on the 6h, 1h and 5m sort fields and token rows carry no `price_change_percentage_5m` field, so `TOKEN_SORT_CANONICAL` is deliberately unchanged and `SearchParamsTest::testShortPriceChangeWindowsArePoolOnly` pins that asymmetry.
-- `pools/search` answers `200` and ignores query parameters it does not recognise, so a missing bound returns a plausible unfiltered list rather than an error. Verified live against `api.dexpaprika.com` by comparing each bound against an unfiltered baseline.
+- Only the 6h, 1h and 5m windows are pools-only. `tokens/search` returns `400` when you sort by one of those three, ignores their filter bounds, and its rows carry no short-window price-change field, so `TOKEN_SORT_CANONICAL` is deliberately unchanged and `SearchParamsTest::testShortPriceChangeWindowsArePoolOnly` pins that asymmetry. The 24h window is different: it sorts and filters on both endpoints, which is why it lands on `filterTokens()` too.
+- Both search endpoints answer `200` and ignore query parameters they do not recognise, so a bound the SDK gets wrong returns a plausible unfiltered list rather than an error. Verified live against `api.dexpaprika.com` by comparing every bound against an unfiltered baseline, with a deliberately misspelled parameter as the control.
 - Updated SDK VERSION constant to 1.6.0.
 
 ## [1.5.0] - 2026-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-08-07
+
+### Added
+- **Short price-change windows on pool search**: `price_change_percentage_6h`, `price_change_percentage_1h` and `price_change_percentage_5m` are now recognised as canonical `sortBy`/`orderBy` values for `PoolsApi::getNetworkPools()` and `PoolsApi::filterPools()`. Previously they fell through to the unknown-field fallback and were sent as `volume_usd_24h`, so a caller asking for the 1h sort got `200` and a full result set ordered by volume.
+- **Price-change bounds on `PoolsApi::filterPools()`**: eight new options, `priceChangePercentage{24h,6h,1h,5m}{Min,Max}`, mapping to `price_change_percentage_{24h,6h,1h,5m}_{min,max}`. `filterPools()` reads named keys, so bounds it does not name cannot be passed at all. The 24h pair is included; the endpoint already accepted it. Bounds are percentages and negative values are the common case: down at least 20 percent in the last hour is `'priceChangePercentage1hMax' => -20`.
+
+### Notes
+- These four windows are pools-only. `tokens/search` returns `400` on the 6h, 1h and 5m sort fields and token rows carry no `price_change_percentage_5m` field, so `TOKEN_SORT_CANONICAL` is deliberately unchanged and `SearchParamsTest::testShortPriceChangeWindowsArePoolOnly` pins that asymmetry.
+- `pools/search` answers `200` and ignores query parameters it does not recognise, so a missing bound returns a plausible unfiltered list rather than an error. Verified live against `api.dexpaprika.com` by comparing each bound against an unfiltered baseline.
+- Updated SDK VERSION constant to 1.6.0.
+
 ## [1.5.0] - 2026-07-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -272,6 +272,38 @@ $filtered = $client->pools->filterPools('ethereum', [
 echo "Found " . count($filtered['results']) . " pools matching criteria\n";
 ```
 
+### Price change windows (pools only)
+
+`pools/search` sorts and filters on four price-change windows: 24h, 6h, 1h and 5m.
+Pass the window as `sortBy`, or bound it with the matching min/max option. Bounds are
+percentages, and a max is normally negative because that is how you ask for a drop.
+
+```php
+// Pools that fell 10% or more in the last hour, worst first
+$dumping = $client->pools->filterPools('ethereum', [
+    'priceChangePercentage1hMax' => -10,
+    'liquidityUsdMin' => 10000,
+    'sortBy' => 'price_change_percentage_1h',
+    'sortDir' => 'asc',
+    'limit' => 10,
+]);
+
+// Fastest movers over the last five minutes
+$movers = $client->pools->getNetworkPools('ethereum', [
+    'orderBy' => 'price_change_percentage_5m',
+    'sort' => 'desc',
+    'limit' => 10,
+]);
+```
+
+Tighten either bound and the result set can legitimately come back empty, because a
+screen for a sharp hourly drop on a well funded pool matches nothing on a calm day.
+An empty `results[]` there is an answer, not a failure.
+
+The 6h, 1h and 5m windows exist on pools only. `tokens/search` returns `400` for them
+and token rows carry no `price_change_percentage_5m` field, so `getTopTokens()` and
+`filterTokens()` still take `price_change_percentage_24h` and nothing shorter.
+
 ### Top Tokens & Token Filtering
 
 ```php

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ $filtered = $client->pools->filterPools('ethereum', [
 echo "Found " . count($filtered['results']) . " pools matching criteria\n";
 ```
 
-### Price change windows (pools only)
+### Price change windows
 
 `pools/search` sorts and filters on four price-change windows: 24h, 6h, 1h and 5m.
 Pass the window as `sortBy`, or bound it with the matching min/max option. Bounds are
@@ -300,9 +300,20 @@ Tighten either bound and the result set can legitimately come back empty, becaus
 screen for a sharp hourly drop on a well funded pool matches nothing on a calm day.
 An empty `results[]` there is an answer, not a failure.
 
-The 6h, 1h and 5m windows exist on pools only. `tokens/search` returns `400` for them
-and token rows carry no `price_change_percentage_5m` field, so `getTopTokens()` and
-`filterTokens()` still take `price_change_percentage_24h` and nothing shorter.
+The 24h window is the only one of the four that also works on tokens. `getTopTokens()`
+sorts by `price_change_percentage_24h`, and `filterTokens()` takes the matching bounds:
+
+```php
+// Tokens down 20% or more on the day
+$dropped = $client->tokens->filterTokens('ethereum', [
+    'priceChangePercentage24hMax' => -20,
+    'limit' => 10,
+]);
+```
+
+The 6h, 1h and 5m windows exist on pools only. `tokens/search` returns `400` when you
+sort by one of them, silently ignores their filter bounds, and token rows carry no
+short-window price-change field at all.
 
 ### Top Tokens & Token Filtering
 

--- a/src/DexPaprika/Api/PoolsApi.php
+++ b/src/DexPaprika/Api/PoolsApi.php
@@ -269,8 +269,12 @@ class PoolsApi extends BaseApi
      *
      * The price-change bounds are read as percentages and negative values are the
      * common case: "down at least 20 percent in the last hour" is
-     * {@code 'priceChangePercentage1hMax' => -20}. These four windows are pools-only;
-     * tokens/search rejects them.
+     * {@code 'priceChangePercentage1hMax' => -20}.
+     *
+     * Only the 6h, 1h and 5m windows are pools-only. tokens/search returns 400 on
+     * those three sort fields and ignores their bounds. The 24h window works on
+     * both endpoints, which is why {@see TokensApi::filterTokens()} carries the
+     * same 24h pair.
      *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param array<string, mixed> $options Filter options:

--- a/src/DexPaprika/Api/PoolsApi.php
+++ b/src/DexPaprika/Api/PoolsApi.php
@@ -70,7 +70,7 @@ class PoolsApi extends BaseApi
      * {@code results[], has_next_page, next_cursor, query}. Each pool exposes
      * id (pool address), chain, dex_id, dex_name, fee, created_at,
      * volume_usd_24h/7d/30d, liquidity_usd, transactions_24h, price_usd,
-     * price_change_percentage_5m/1h/24h and tokens[].
+     * price_change_percentage_5m/1h/6h/24h and tokens[].
      *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param array<string, mixed> $options Additional options:
@@ -260,12 +260,17 @@ class PoolsApi extends BaseApi
     }
 
     /**
-     * Filter pools on a network by volume, liquidity, transactions, and creation date
+     * Filter pools on a network by volume, liquidity, transactions, price change, and creation date
      *
      * Backed by the unified /networks/{network}/pools/search endpoint, which is
      * cursor-paginated and returns {@code results[], has_next_page, next_cursor, query}.
      * Legacy sort-field values and legacy filter parameter names are mapped to the
      * canonical search names so requests do not 400.
+     *
+     * The price-change bounds are read as percentages and negative values are the
+     * common case: "down at least 20 percent in the last hour" is
+     * {@code 'priceChangePercentage1hMax' => -20}. These four windows are pools-only;
+     * tokens/search rejects them.
      *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param array<string, mixed> $options Filter options:
@@ -281,6 +286,14 @@ class PoolsApi extends BaseApi
      *  - float $liquidityUsdMin: Minimum liquidity in USD
      *  - float $liquidityUsdMax: Maximum liquidity in USD
      *  - int $txns24hMin: Minimum number of transactions in 24h
+     *  - float $priceChangePercentage24hMin: Minimum 24h price change, in percent
+     *  - float $priceChangePercentage24hMax: Maximum 24h price change, in percent
+     *  - float $priceChangePercentage6hMin: Minimum 6h price change, in percent
+     *  - float $priceChangePercentage6hMax: Maximum 6h price change, in percent
+     *  - float $priceChangePercentage1hMin: Minimum 1h price change, in percent
+     *  - float $priceChangePercentage1hMax: Maximum 1h price change, in percent
+     *  - float $priceChangePercentage5mMin: Minimum 5m price change, in percent
+     *  - float $priceChangePercentage5mMax: Maximum 5m price change, in percent
      *  - string|int $createdAfter: Only pools created after this time (Unix timestamp)
      *  - string|int $createdBefore: Only pools created before this time (Unix timestamp)
      *  - bool $asObject: Whether to return the response as an object (default: false)
@@ -329,6 +342,30 @@ class PoolsApi extends BaseApi
         }
         if (isset($options['txns24hMin'])) {
             $params['txns_24h_min'] = $options['txns24hMin'];
+        }
+        if (isset($options['priceChangePercentage24hMin'])) {
+            $params['price_change_percentage_24h_min'] = $options['priceChangePercentage24hMin'];
+        }
+        if (isset($options['priceChangePercentage24hMax'])) {
+            $params['price_change_percentage_24h_max'] = $options['priceChangePercentage24hMax'];
+        }
+        if (isset($options['priceChangePercentage6hMin'])) {
+            $params['price_change_percentage_6h_min'] = $options['priceChangePercentage6hMin'];
+        }
+        if (isset($options['priceChangePercentage6hMax'])) {
+            $params['price_change_percentage_6h_max'] = $options['priceChangePercentage6hMax'];
+        }
+        if (isset($options['priceChangePercentage1hMin'])) {
+            $params['price_change_percentage_1h_min'] = $options['priceChangePercentage1hMin'];
+        }
+        if (isset($options['priceChangePercentage1hMax'])) {
+            $params['price_change_percentage_1h_max'] = $options['priceChangePercentage1hMax'];
+        }
+        if (isset($options['priceChangePercentage5mMin'])) {
+            $params['price_change_percentage_5m_min'] = $options['priceChangePercentage5mMin'];
+        }
+        if (isset($options['priceChangePercentage5mMax'])) {
+            $params['price_change_percentage_5m_max'] = $options['priceChangePercentage5mMax'];
         }
         if (isset($options['createdAfter'])) {
             $params['created_after'] = $options['createdAfter'];

--- a/src/DexPaprika/Api/TokensApi.php
+++ b/src/DexPaprika/Api/TokensApi.php
@@ -210,12 +210,17 @@ class TokensApi extends BaseApi
     }
 
     /**
-     * Filter tokens on a network by volume, liquidity, FDV, transactions, and creation date
+     * Filter tokens on a network by volume, liquidity, FDV, transactions, 24h price
+     * change, and creation date
      *
      * Backed by the unified /networks/{network}/tokens/search endpoint, which is
      * cursor-paginated and returns {@code results[], has_next_page, next_cursor, query}.
      * Legacy sort-field values and legacy filter parameter names are mapped to the
      * canonical search names so requests do not 400.
+     *
+     * 24h is the only price-change window this endpoint honours. The 6h, 1h and 5m
+     * bounds are accepted with a 200 and then ignored, so they are not exposed here;
+     * {@see PoolsApi::filterPools()} has all four.
      *
      * @param string $networkId Network ID (e.g., ethereum, solana)
      * @param array<string, mixed> $options Filter options:
@@ -230,6 +235,8 @@ class TokensApi extends BaseApi
      *  - float $fdvMin: Minimum fully diluted valuation in USD
      *  - float $fdvMax: Maximum fully diluted valuation in USD
      *  - int $txns24hMin: Minimum number of transactions in 24h
+     *  - float $priceChangePercentage24hMin: Minimum 24h price change, in percent
+     *  - float $priceChangePercentage24hMax: Maximum 24h price change, in percent
      *  - string|int $createdAfter: Only tokens created after this time (Unix timestamp)
      *  - string|int $createdBefore: Only tokens created before this time (Unix timestamp)
      *  - bool $asObject: Whether to return the response as an object (default: false)
@@ -277,6 +284,12 @@ class TokensApi extends BaseApi
         }
         if (isset($options['txns24hMin'])) {
             $params['txns_24h_min'] = $options['txns24hMin'];
+        }
+        if (isset($options['priceChangePercentage24hMin'])) {
+            $params['price_change_percentage_24h_min'] = $options['priceChangePercentage24hMin'];
+        }
+        if (isset($options['priceChangePercentage24hMax'])) {
+            $params['price_change_percentage_24h_max'] = $options['priceChangePercentage24hMax'];
         }
         if (isset($options['createdAfter'])) {
             $params['created_after'] = $options['createdAfter'];

--- a/src/DexPaprika/Client.php
+++ b/src/DexPaprika/Client.php
@@ -75,7 +75,7 @@ class Client
     /**
      * SDK version
      */
-    public const VERSION = '1.5.0';
+    public const VERSION = '1.6.0';
 
     /**
      * Create a new DexPaprika client

--- a/src/DexPaprika/Utils/SearchParams.php
+++ b/src/DexPaprika/Utils/SearchParams.php
@@ -39,6 +39,8 @@ class SearchParams
      *
      * The 6h, 1h and 5m price-change windows are pools-only. tokens/search
      * returns 400 on them, so they must not be copied into TOKEN_SORT_CANONICAL.
+     * price_change_percentage_24h belongs in both tables and is not part of that
+     * asymmetry.
      *
      * @var array<int, string>
      */

--- a/src/DexPaprika/Utils/SearchParams.php
+++ b/src/DexPaprika/Utils/SearchParams.php
@@ -37,6 +37,9 @@ class SearchParams
     /**
      * Canonical sort fields accepted as-is by pools/search.
      *
+     * The 6h, 1h and 5m price-change windows are pools-only. tokens/search
+     * returns 400 on them, so they must not be copied into TOKEN_SORT_CANONICAL.
+     *
      * @var array<int, string>
      */
     private const POOL_SORT_CANONICAL = [
@@ -48,6 +51,9 @@ class SearchParams
         'created_at',
         'price_usd',
         'price_change_percentage_24h',
+        'price_change_percentage_6h',
+        'price_change_percentage_1h',
+        'price_change_percentage_5m',
     ];
 
     /**

--- a/tests/DexPaprika/PoolsApiTest.php
+++ b/tests/DexPaprika/PoolsApiTest.php
@@ -190,6 +190,74 @@ class PoolsApiTest extends TestCase
         ]);
     }
 
+    public function testFilterPoolsSendsPriceChangeBounds(): void
+    {
+        // pools/search answers 200 and ignores query parameters it does not know,
+        // so a bound the SDK forgets to send comes back as a plausible unfiltered
+        // list rather than an error. Pin all eight names and keep the negatives
+        // negative.
+        $mockApi = $this->getMockBuilder(PoolsApi::class)
+            ->setConstructorArgs([$this->createMockClient([])])
+            ->onlyMethods(['get'])
+            ->getMock();
+
+        $mockApi->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/networks/ethereum/pools/search'),
+                $this->equalTo([
+                    'limit' => 10,
+                    'order_by' => 'price_change_percentage_1h',
+                    'sort' => 'desc',
+                    'price_change_percentage_24h_min' => -80,
+                    'price_change_percentage_24h_max' => -20,
+                    'price_change_percentage_6h_min' => -15.5,
+                    'price_change_percentage_6h_max' => 40,
+                    'price_change_percentage_1h_min' => 50,
+                    'price_change_percentage_1h_max' => 500,
+                    'price_change_percentage_5m_min' => 1,
+                    'price_change_percentage_5m_max' => 3,
+                ])
+            )
+            ->willReturn(['results' => [], 'has_next_page' => false, 'next_cursor' => null]);
+
+        $mockApi->filterPools('ethereum', [
+            'limit' => 10,
+            'sortBy' => 'price_change_percentage_1h',
+            'sortDir' => 'desc',
+            'priceChangePercentage24hMin' => -80,
+            'priceChangePercentage24hMax' => -20,
+            'priceChangePercentage6hMin' => -15.5,
+            'priceChangePercentage6hMax' => 40,
+            'priceChangePercentage1hMin' => 50,
+            'priceChangePercentage1hMax' => 500,
+            'priceChangePercentage5mMin' => 1,
+            'priceChangePercentage5mMax' => 3,
+        ]);
+    }
+
+    public function testFilterPoolsKeepsZeroPriceChangeBounds(): void
+    {
+        // isset() is the guard used throughout filterPools, so a 0 bound survives.
+        // "did not drop more than 0 percent" is a real query and empty() would eat it.
+        $mockApi = $this->getMockBuilder(PoolsApi::class)
+            ->setConstructorArgs([$this->createMockClient([])])
+            ->onlyMethods(['get'])
+            ->getMock();
+
+        $mockApi->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/networks/ethereum/pools/search'),
+                $this->equalTo([
+                    'price_change_percentage_1h_min' => 0,
+                ])
+            )
+            ->willReturn(['results' => [], 'has_next_page' => false, 'next_cursor' => null]);
+
+        $mockApi->filterPools('ethereum', ['priceChangePercentage1hMin' => 0]);
+    }
+
     public function testGetNetworkPoolsValidatesNetworkId(): void
     {
         $api = new PoolsApi($this->createMockClient([]));

--- a/tests/DexPaprika/TokensApiTest.php
+++ b/tests/DexPaprika/TokensApiTest.php
@@ -427,4 +427,62 @@ class TokensApiTest extends TestCase
             'fdvMin' => 1000000,
         ]);
     }
+
+    public function testFilterTokensSends24hPriceChangeBounds(): void
+    {
+        // tokens/search honours the 24h bounds and answers 200 while ignoring
+        // anything it does not recognise, so a typo here would look like a working
+        // filter returning an unfiltered page. Pin both names, and keep the
+        // negative max negative because a max on a price change usually is.
+        $mockApi = $this->getMockBuilder(TokensApi::class)
+            ->setConstructorArgs([$this->createMockClient([])])
+            ->onlyMethods(['get'])
+            ->getMock();
+
+        $mockApi->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/networks/ethereum/tokens/search'),
+                $this->equalTo([
+                    'limit' => 5,
+                    'price_change_percentage_24h_min' => -80,
+                    'price_change_percentage_24h_max' => -20,
+                ])
+            )
+            ->willReturn(['results' => [], 'has_next_page' => false, 'next_cursor' => null]);
+
+        $mockApi->filterTokens('ethereum', [
+            'limit' => 5,
+            'priceChangePercentage24hMin' => -80,
+            'priceChangePercentage24hMax' => -20,
+        ]);
+    }
+
+    public function testFilterTokensDropsShortPriceChangeWindows(): void
+    {
+        // tokens/search accepts price_change_percentage_{6h,1h,5m}_{min,max} with a
+        // 200 and then ignores them, so sending them would promise filtering the API
+        // never does. filterTokens reads named keys, so the omission is the guard.
+        $mockApi = $this->getMockBuilder(TokensApi::class)
+            ->setConstructorArgs([$this->createMockClient([])])
+            ->onlyMethods(['get'])
+            ->getMock();
+
+        $mockApi->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/networks/ethereum/tokens/search'),
+                $this->equalTo([
+                    'price_change_percentage_24h_min' => 10,
+                ])
+            )
+            ->willReturn(['results' => [], 'has_next_page' => false, 'next_cursor' => null]);
+
+        $mockApi->filterTokens('ethereum', [
+            'priceChangePercentage24hMin' => 10,
+            'priceChangePercentage6hMin' => 10,
+            'priceChangePercentage1hMin' => 10,
+            'priceChangePercentage5mMin' => 10,
+        ]);
+    }
 }

--- a/tests/DexPaprika/Utils/SearchParamsTest.php
+++ b/tests/DexPaprika/Utils/SearchParamsTest.php
@@ -27,6 +27,26 @@ class SearchParamsTest extends TestCase
         }
     }
 
+    public function testMapPoolSortFieldPassesShortPriceChangeWindowsThrough(): void
+    {
+        // pools/search accepts these three, so they must reach the wire unchanged.
+        // If any drops out of the canonical list it silently becomes volume_usd_24h
+        // and the caller gets 200 with a result set sorted by the wrong column.
+        foreach (['price_change_percentage_6h', 'price_change_percentage_1h', 'price_change_percentage_5m'] as $field) {
+            $this->assertEquals($field, SearchParams::mapPoolSortField($field));
+        }
+    }
+
+    public function testShortPriceChangeWindowsArePoolOnly(): void
+    {
+        // tokens/search returns 400 on these windows and token rows carry no
+        // price_change_percentage_5m field at all. Adding them to the token table
+        // would turn a working request into a 400, so pin the asymmetry here.
+        foreach (['price_change_percentage_6h', 'price_change_percentage_1h', 'price_change_percentage_5m'] as $field) {
+            $this->assertEquals('volume_usd_24h', SearchParams::mapTokenSortField($field));
+        }
+    }
+
     public function testMapPoolSortFieldFallsBackToDefault(): void
     {
         $this->assertEquals('volume_usd_24h', SearchParams::mapPoolSortField('not_a_field'));
@@ -90,6 +110,25 @@ class SearchParamsTest extends TestCase
             'sort' => 'desc',
             'limit' => 10,
         ], $mapped);
+    }
+
+    public function testMapPoolFilterParamsLeavesPriceChangeBoundsAlone(): void
+    {
+        // These eight are already canonical. The rename table must not touch them,
+        // and negative bounds have to survive intact because a max on a price change
+        // is normally negative.
+        $bounds = [
+            'price_change_percentage_24h_min' => -50,
+            'price_change_percentage_24h_max' => -20,
+            'price_change_percentage_6h_min' => 5,
+            'price_change_percentage_6h_max' => 100,
+            'price_change_percentage_1h_min' => -0.5,
+            'price_change_percentage_1h_max' => 12.5,
+            'price_change_percentage_5m_min' => 1,
+            'price_change_percentage_5m_max' => 3,
+        ];
+
+        $this->assertEquals($bounds, SearchParams::mapPoolFilterParams($bounds));
     }
 
     public function testMapTokenFilterParamsRenamesLegacyKeys(): void


### PR DESCRIPTION
## What this fixes

`/networks/{network}/pools/search` accepts eleven `order_by` values. Three were
missing from `POOL_SORT_CANONICAL` in the PHP SDK:

- `price_change_percentage_6h`
- `price_change_percentage_1h`
- `price_change_percentage_5m`

The failure mode is quiet, which is the reason to care. `mapSortField()` maps any
unrecognised sort field to `volume_usd_24h` before the request leaves the SDK, so
the API never gets a chance to reject it. Someone asking for the 1h sort received
HTTP 200 and a full page of pools ordered by volume. No exception, no warning,
just the wrong column with a plausible looking result set.

`filterPools()` reads named keys out of the options array, so a bound the method
does not name cannot be passed at all. This PR adds all eight bounds,
`priceChangePercentage` for 24h, 6h, 1h and 5m in `Min` and `Max` form, mapping to
`price_change_percentage_{window}_{min,max}`. The 24h pair was absent too, even
though the endpoint already accepted it.

`filterTokens()` gets the 24h pair for the same reason. `tokens/search` has
honoured `price_change_percentage_24h_min` and `_max` all along and the SDK had no
way to send them.

Bounds are percentages, and negative values are the ordinary case rather than an
edge case. "Down at least 20 percent in the last hour" is
`'priceChangePercentage1hMax' => -20`. PHP renders `-20.0` as `-20` through
`http_build_query`, so no explicit float formatting is needed on the way out. I
confirmed that on the wire.

## Verified live against api.dexpaprika.com

Not against the OpenAPI spec, and not against a docs page.

**Sort fields.** All three return 200 on `pools/search`. An unknown value returns
400 with the accepted list:

```
$ curl -s "…/networks/ethereum/pools/search?order_by=not_a_field"
{"message":"invalid query parameters: order_by (must be one of [volume_usd_24h
volume_usd_7d volume_usd_30d liquidity_usd txns_24h created_at price_usd
price_change_percentage_24h price_change_percentage_6h price_change_percentage_1h
price_change_percentage_5m])"}
```

**Filters needed a different method.** An unrecognised query parameter is ignored
and still answers 200 with a full unfiltered page, so the status code carries no
information about whether a filter applied. Every bound was checked against an
unfiltered baseline instead:

| check | 1h values returned |
|---|---|
| unfiltered baseline | `0`, `0.0091`, `0.2405`, `0.0135`, `-0.0102` |
| `price_change_percentage_1h_min=50` | `76.83`, `57.47` |
| `price_change_percentage_1h_max=-20` | `-60.52`, `-20.81`, `-26.41`, `-23.65`, `-80.88` |
| `price_change_percentage_1h_minimum=50` (misspelled) | 200, and the baseline page returns |

That last row is the control. A wrong parameter name is indistinguishable from a
correct one by status code alone, so the baseline contrast is what actually proves
the eight names are right.

**End to end through the SDK.** I drove the built SDK against the live API rather
than stopping at mocks. All eight pool bounds returned zero rows violating the
bound, and each of the three sort fields came back genuinely ordered. Both README
pool examples run verbatim. The hourly-drop example currently returns an empty
`results[]`, which is honest: with `liquidity_usd_min=10000` the worst 1h performer
on ethereum right now is `-8.14`, so nothing clears a `-10` threshold. Drop the
liquidity floor and the same bound returns rows down to `-80.88`.

## Which windows are pools-only, corrected

An earlier revision of this branch said in the phpDoc and the CHANGELOG that all
four windows are pools-only. That was wrong, and it inverted the asymmetry the
branch exists to protect. Only the three short windows are.

| on `tokens/search` | 24h | 6h, 1h, 5m |
|---|---|---|
| sort by the window | 200 | 400 |
| min/max filter bounds | applied | accepted with 200, then ignored |
| present on the row | yes | field absent from the JSON |

Re-checked on ethereum, against an unfiltered baseline of
`[95.70, -0.07, 0.24, -0.01, 0.48, 0.03]`:

| check | 24h values returned |
|---|---|
| `price_change_percentage_24h_min=20` | `95.70`, `36.62`, `16672.56`, `22.96`, `33.24`, `1251.05` |
| `price_change_percentage_24h_max=-20` | `-99.41`, `-22.53`, `-56.11`, `-86.58`, `-27.49`, `-46.22` |
| `price_change_pct_24h_min=20` (misspelled) | identical to the baseline |
| `price_change_percentage_6h_min=20` | identical to the baseline |
| `price_change_percentage_1h_min=20` | identical to the baseline |
| `price_change_percentage_5m_min=20` | identical to the baseline |

The misspelled control is what proves the correct spelling did something. The
short-window rows landing exactly on the baseline is what proves those three are
ignored. Sorting agrees: `order_by=price_change_percentage_24h` returns 200 on
tokens, while the other three return 400 with an enum listing neither.

So `TOKEN_SORT_CANONICAL` stays unchanged, `filterTokens()` gains the 24h pair and
nothing shorter, and `testShortPriceChangeWindowsArePoolOnly` pins the three-window
asymmetry so a later sweep tidying up the two tables does not copy the windows
across and turn working token requests into 400s. The existing
`price_usd => volume_usd_24h` token remap is load-bearing for the same reason and
stays as it is: `tokens/search?order_by=price_usd` still returns 400 even though
its own error message advertises `price_usd` in the accepted list.

## Failing controls

A check that cannot fail has verified nothing, so I broke this four ways:

1. Removed `price_change_percentage_1h` from `POOL_SORT_CANONICAL`. The unit test
   failed with `order_by` reading `volume_usd_24h` instead of the requested field,
   and the live check failed with the 1h sort returning baseline order. That is
   the original bug, reproduced on demand.
2. Renamed `price_change_percentage_6h_min` to `price_change_pct_6h_min` in
   `PoolsApi`. `testFilterPoolsSendsPriceChangeBounds` failed on the mismatched key.
3. Renamed `price_change_percentage_24h_min` to `price_change_pct_24h_min` in
   `TokensApi`. Both new token tests failed on the mismatched key.
4. Made `filterTokens()` forward `priceChangePercentage6hMin`.
   `testFilterTokensDropsShortPriceChangeWindows` failed on the extra key.

All were restored, and the file blob hashes match their pre-control state.

## Tests

`composer install && vendor/bin/phpunit`

- This branch: 113 tests, 363 assertions, green
- Base `sdkv1.0.0` with the change stashed: 106 tests, 352 assertions, green

No pre-existing failures, and none introduced. Seven tests added.

Consistent with the hosted MCP worker, the npm MCP (dexpaprika-mcp#40) and the Go
SDK (dexpaprika-sdk-go#22), which shipped the same three tables.

https://claude.ai/code/session_016Zw5oLXk2fVxkVJvgqrc9j
