### PR TITLE
Create a GitHub Release when a v* tag is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+# Cut a GitHub Release whenever a v* tag is pushed.
+#
+# Why this exists: tags were being pushed without releases, so every repo's
+# front page advertised a version months behind what npm, PyPI, Packagist and
+# the Go proxy were actually serving. dexpaprika-mcp showed v2.3.2 while npm
+# served 2.4.0. Registries that score on release freshness, Glama among them,
+# read the release, not the tag.
+
+on:
+  push:
+    tags: ["v*"]
+
+# Read-only by default; the job below widens to write for this one step.
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull the CHANGELOG section for this tag
+        run: |
+          set -euo pipefail
+          v="${GITHUB_REF_NAME#v}"
+          # Matches "## [1.7.0] - date" and "## 1.7.0 - date" alike.
+          awk -v v="$v" '
+            !f && $0 ~ ("^## \\[?" v "\\]?([^0-9.]|$)") { f=1; next }
+            f && /^## / { exit }
+            f { print }
+          ' CHANGELOG.md > notes.md
+          # Refuse to publish empty notes. An unreleased-only CHANGELOG is a
+          # real mistake: dexpaprika-sdk-go was tagged v1.7.0 while its
+          # CHANGELOG still filed the work under [Unreleased].
+          if [ ! -s notes.md ] || ! grep -q '[^[:space:]]' notes.md; then
+            echo "::error::No CHANGELOG section for ${v}. Add a '## [${v}]' heading before tagging." >&2
+            exit 1
+          fi
+          echo "--- notes for ${v} ---"
+          cat notes.md
+
+      - name: Create the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file notes.md \
+            --verify-tag \
+            --latest


### PR DESCRIPTION
Tags were being pushed without GitHub Releases, so this repo's front page advertised a version well behind what the registry actually served. Before today: `dexpaprika-mcp` showed v2.3.2 while npm served 2.4.0, `dexpaprika-sdk-ts` showed v1.5.0 against npm's 1.9.0, and `dexpaprika-sdk-php` showed v1.1.0 against a v1.7.0 tag.

I backfilled the missing releases by hand. This stops it recurring: push a `v*` tag, get a release, with notes taken from the matching CHANGELOG section.

`dexpaprika-cli` already had this and was the only repo whose release badge was correct. This is that idea, minus the binary-building steps it does not need here.

## It refuses to publish empty notes

If there is no `## [x.y.z]` heading for the tag, the job fails instead of creating a release with a blank body. That is not hypothetical: `dexpaprika-sdk-go` was tagged v1.7.0 while its CHANGELOG still filed the work under `## [Unreleased]`.

## Verified before opening this

The awk extraction was run against the real CHANGELOGs at their tagged commits, covering both heading styles in use (`## [2.4.0] - date` and `## 1.9.0 (date)`), plus three failing controls:

```
mcp  2.4.0  -> 10 lines
ts   1.9.0  -> 12 lines
go   1.7.0  ->  0 lines   (only [Unreleased] present, guard fires)
mcp  9.9.9  ->  0 lines   (absent version, guard fires)
prefix collision: 2.4.0 against a "## [2.4.01]" heading picks the right section
```

Token stays `contents: read` at workflow level; only the release job widens to `contents: write`.
