### PR TITLE
feat: optional API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-08-14
+
+### Added
+- **Optional API key.** `Config::setApiKey()`, falling back to the `DEXPAPRIKA_API_KEY` environment variable when no key is set. Keyless remains the default and is unchanged: without a key the client sends exactly what it sent before. The key is transmitted as the **entire** `Authorization` value, with no `Bearer` prefix and no other scheme word, because the API checksums the raw header and a scheme word returns 401.
+- `Config::getApiKey()` resolves the precedence, and `Config::API_KEY_ENV_VAR` names the variable.
+- The host is never inferred from the presence of a key. Free keys are served from the default base URL and only Pro moves to `api-pro.dexpaprika.com`, set with `setBaseUrl()`. Sending a free key to the Pro host returns 403, so guessing would break exactly the people who just registered.
+
+### Notes
+- A key carrying CR, LF or NUL is dropped rather than sanitised. A mangled key authenticates as nobody, and because the data endpoints ignore an unreadable key instead of rejecting it, the caller would never find out.
+- 12 new tests, 26 assertions, asserting on the headers that actually reach a Guzzle mock handler rather than on stored values: the bare-key format against five scheme words, keyless behaviour, precedence, whitespace trimming, header-injection rejection, the host rules, and an end-to-end pass through the real `Client` constructor.
+- A key the API cannot read is ignored rather than rejected on the data endpoints: the call returns `200` with real data while quietly serving the keyless tier. `/usage` and its `plan` field are the way to confirm a key is landing.
+
 ## [1.7.0] - 2026-08-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -142,6 +142,49 @@ try {
 }
 ```
 
+## Using an API key (optional)
+
+**The SDK works without a key and always will.** No signup, no card. Everything
+below is optional.
+
+A free key raises the monthly credit allowance. It does **not** raise the
+per-minute request limit, which is the same on both free tiers. Current figures
+are on the [rate limits page](https://docs.dexpaprika.com/knowledge-base/rate-limits).
+
+```php
+use DexPaprika\Client;
+use DexPaprika\Config;
+
+// Explicit
+$config = (new Config())->setApiKey('api_your_key_here');
+$client = new Client(null, null, false, $config);
+
+// Or leave it out and set DEXPAPRIKA_API_KEY in the environment
+$client = new Client();
+```
+
+`setApiKey()` beats the environment variable, and no key at all keeps the
+previous keyless behaviour unchanged.
+
+**There is no `Bearer` prefix.** The key is sent as the entire `Authorization`
+value, which is what the API expects; a scheme word returns 401. You never write
+the header yourself, so this only matters when debugging what went out.
+
+**Pro customers** also set the base URL, because the host does not change on its
+own. Free keys are served from the default host and sending one to the Pro host
+returns 403, so the switch has to be deliberate:
+
+```php
+$config = (new Config())
+    ->setApiKey('api_your_pro_key')
+    ->setBaseUrl('https://api-pro.dexpaprika.com');
+```
+
+**One gotcha worth knowing.** On the data endpoints a key the API cannot read is
+ignored rather than rejected: the call returns `200` with real data and you are
+quietly served as an anonymous caller. To confirm a key is landing, call `/usage`
+and check the `plan` field; `keyless` means the key never arrived.
+
 ## Advanced Configuration
 
 ```php

--- a/src/DexPaprika/Client.php
+++ b/src/DexPaprika/Client.php
@@ -75,7 +75,7 @@ class Client
     /**
      * SDK version
      */
-    public const VERSION = '1.7.0';
+    public const VERSION = '1.8.0';
 
     /**
      * Create a new DexPaprika client
@@ -97,13 +97,21 @@ class Client
         $this->transformResponses = $transformResponses;
         
         // Initialize HTTP client if not provided
+        $headers = [
+            'Accept' => 'application/json',
+            'User-Agent' => 'dexpaprika-sdk-php/' . self::VERSION,
+        ];
+
+        $apiKey = $this->config->getApiKey();
+        if ($apiKey !== null) {
+            // The whole value, with no scheme word in front of it.
+            $headers['Authorization'] = $apiKey;
+        }
+
         $this->httpClient = $httpClient ?? new GuzzleClient([
             'base_uri' => $this->baseUrl,
             'timeout' => $this->config->getTimeout(),
-            'headers' => [
-                'Accept' => 'application/json',
-                'User-Agent' => 'dexpaprika-sdk-php/' . self::VERSION,
-            ],
+            'headers' => $headers,
         ]);
 
         // Initialize API services

--- a/src/DexPaprika/Config.php
+++ b/src/DexPaprika/Config.php
@@ -12,9 +12,24 @@ use DexPaprika\Cache\CacheInterface;
 class Config
 {
     /**
+     * Environment variable consulted when no key is set explicitly
+     */
+    public const API_KEY_ENV_VAR = 'DEXPAPRIKA_API_KEY';
+
+    /**
      * Base API URL
+     *
+     * Serves keyless callers and registered free keys alike. Only Pro moves to
+     * api-pro.dexpaprika.com, which callers set with setBaseUrl(). The host is
+     * never inferred from the presence of a key: sending a free key to the Pro
+     * host returns 403, so guessing would break the people who just registered.
      */
     private string $baseUrl = 'https://api.dexpaprika.com';
+
+    /**
+     * Optional API key. Null means keyless, which is the default and works.
+     */
+    private ?string $apiKey = null;
     
     /**
      * API Timeout in seconds
@@ -48,6 +63,66 @@ class Config
      */
     private int $cacheTtl = 3600;
     
+    /**
+     * Set the API key sent with every request
+     *
+     * Optional. Without one the client is keyless, which works and needs no
+     * signup. An explicit key here beats the DEXPAPRIKA_API_KEY environment
+     * variable.
+     *
+     * The key is sent as the entire Authorization value. There is no "Bearer"
+     * prefix and no other scheme word: the API checksums the raw header, so a
+     * scheme word returns 401. This is the most common reason a working key
+     * looks broken.
+     *
+     * @param string|null $apiKey The API key, or null for keyless
+     * @return self
+     */
+    public function setApiKey(?string $apiKey): self
+    {
+        $this->apiKey = self::sanitizeApiKey($apiKey);
+        return $this;
+    }
+
+    /**
+     * Get the API key in use, or null when running keyless
+     *
+     * Falls back to the DEXPAPRIKA_API_KEY environment variable when no key was
+     * set explicitly.
+     */
+    public function getApiKey(): ?string
+    {
+        if ($this->apiKey !== null) {
+            return $this->apiKey;
+        }
+
+        $fromEnv = getenv(self::API_KEY_ENV_VAR);
+
+        return self::sanitizeApiKey($fromEnv === false ? null : $fromEnv);
+    }
+
+    /**
+     * Trim a key and reject anything that could break out of a header
+     *
+     * A key carrying CR, LF or NUL is dropped rather than mangled: a mangled key
+     * authenticates as nobody, and because the data endpoints ignore an
+     * unreadable key instead of rejecting it, the caller would never find out.
+     */
+    private static function sanitizeApiKey(?string $apiKey): ?string
+    {
+        if ($apiKey === null) {
+            return null;
+        }
+
+        $trimmed = trim($apiKey);
+
+        if ($trimmed === '' || preg_match('/[\r\n\x00]/', $trimmed) === 1) {
+            return null;
+        }
+
+        return $trimmed;
+    }
+
     /**
      * Set the base API URL
      *

--- a/tests/DexPaprika/ApiKeyTest.php
+++ b/tests/DexPaprika/ApiKeyTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DexPaprika\Tests;
+
+use DexPaprika\Client;
+use DexPaprika\Config;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Optional API key, and the header rules that go with it.
+ *
+ * Keyless is the default and must keep working untouched. The Bearer rule is the
+ * regression this file exists for: `Authorization: Bearer api_...` returns 401
+ * because the API checksums the raw header value, and the mistake has resurfaced
+ * three times in four months.
+ */
+class ApiKeyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        putenv(Config::API_KEY_ENV_VAR);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv(Config::API_KEY_ENV_VAR);
+    }
+
+    /**
+     * Headers that actually reached the wire, rather than what was stored.
+     *
+     * @return array<string, array<int, string>>
+     */
+    private function headersFor(?Config $config = null): array
+    {
+        $sent = [];
+        $stack = HandlerStack::create(new MockHandler([new Response(200, [], '[]')]));
+        $stack->push(Middleware::history($sent));
+
+        $config ??= new Config();
+        $headers = [
+            'Accept' => 'application/json',
+            'User-Agent' => 'dexpaprika-sdk-php/' . Client::VERSION,
+        ];
+        $apiKey = $config->getApiKey();
+        if ($apiKey !== null) {
+            $headers['Authorization'] = $apiKey;
+        }
+
+        $guzzle = new GuzzleClient([
+            'handler' => $stack,
+            'base_uri' => $config->getBaseUrl(),
+            'headers' => $headers,
+        ]);
+        $guzzle->request('GET', '/networks');
+
+        /** @var Request $request */
+        $request = $sent[0]['request'];
+
+        return $request->getHeaders();
+    }
+
+    private function headerValue(array $headers, string $name): ?string
+    {
+        foreach ($headers as $key => $values) {
+            if (strcasecmp($key, $name) === 0) {
+                return $values[0];
+            }
+        }
+
+        return null;
+    }
+
+    // ── The Bearer rule ─────────────────────────────────────────────────────
+
+    public function testKeyIsTheEntireAuthorizationValue(): void
+    {
+        $config = (new Config())->setApiKey('api_abc123');
+        $this->assertSame('api_abc123', $this->headerValue($this->headersFor($config), 'Authorization'));
+    }
+
+    public function testNoSchemeWordIsEverPrepended(): void
+    {
+        $config = (new Config())->setApiKey('api_abc123');
+        $value = (string) $this->headerValue($this->headersFor($config), 'Authorization');
+
+        foreach (['Bearer', 'Token', 'ApiKey', 'Basic', 'Key'] as $scheme) {
+            $this->assertStringStartsNotWith($scheme, $value);
+            $this->assertStringStartsNotWith(strtolower($scheme), strtolower($value));
+        }
+    }
+
+    // ── Keyless stays the default ───────────────────────────────────────────
+
+    public function testNoKeySendsNoAuthorizationHeader(): void
+    {
+        $this->assertNull($this->headerValue($this->headersFor(), 'Authorization'));
+    }
+
+    public function testBlankKeyIsKeylessNotAnEmptyHeader(): void
+    {
+        foreach (['', '   ', "\t"] as $blank) {
+            $config = (new Config())->setApiKey($blank);
+            $this->assertNull($config->getApiKey(), 'blank key should resolve to keyless');
+        }
+    }
+
+    // ── Precedence ──────────────────────────────────────────────────────────
+
+    public function testEnvironmentVariableIsUsedWhenNoKeyIsSet(): void
+    {
+        putenv(Config::API_KEY_ENV_VAR . '=api_from_env');
+        $this->assertSame('api_from_env', (new Config())->getApiKey());
+    }
+
+    public function testExplicitKeyBeatsTheEnvironment(): void
+    {
+        putenv(Config::API_KEY_ENV_VAR . '=api_from_env');
+        $this->assertSame('api_explicit', (new Config())->setApiKey('api_explicit')->getApiKey());
+    }
+
+    public function testSurroundingWhitespaceIsTrimmed(): void
+    {
+        putenv(Config::API_KEY_ENV_VAR . "=  api_padded\n");
+        $this->assertSame('api_padded', (new Config())->getApiKey());
+    }
+
+    // ── Header injection ────────────────────────────────────────────────────
+
+    public function testKeyWithControlCharactersIsDropped(): void
+    {
+        foreach (["api_a\r\nX-Evil: 1", "api_a\nb", "api_a\0b"] as $hostile) {
+            $this->assertNull(
+                (new Config())->setApiKey($hostile)->getApiKey(),
+                'a key carrying control characters must be dropped, not mangled'
+            );
+        }
+    }
+
+    // ── Identification ──────────────────────────────────────────────────────
+
+    public function testUserAgentCarriesTheVersion(): void
+    {
+        $this->assertSame(
+            'dexpaprika-sdk-php/' . Client::VERSION,
+            $this->headerValue($this->headersFor(), 'User-Agent')
+        );
+    }
+
+    // ── Host rules ──────────────────────────────────────────────────────────
+
+    public function testAKeyAloneNeverChangesTheHost(): void
+    {
+        // Free keys are served from the default host; only Pro moves, and a free
+        // key sent to the Pro host returns 403.
+        $config = (new Config())->setApiKey('api_abc123');
+        $this->assertSame('https://api.dexpaprika.com', $config->getBaseUrl());
+    }
+
+    public function testProCustomersSetTheHostExplicitly(): void
+    {
+        $config = (new Config())
+            ->setApiKey('api_pro')
+            ->setBaseUrl('https://api-pro.dexpaprika.com');
+        $this->assertSame('https://api-pro.dexpaprika.com', $config->getBaseUrl());
+    }
+
+    public function testTheClientSendsTheKeyItWasConfiguredWith(): void
+    {
+        // End to end through the real constructor, not a hand-built Guzzle client.
+        $config = (new Config())->setApiKey('api_end_to_end');
+        $client = new Client(null, null, false, $config);
+
+        $headers = $client->getHttpClient()->getConfig('headers');
+        $this->assertSame('api_end_to_end', $headers['Authorization'] ?? null);
+        $this->assertStringStartsNotWith('Bearer', (string) ($headers['Authorization'] ?? ''));
+    }
+}


### PR DESCRIPTION
Last of the four in #166 / [devrel#169](https://github.com/coinpaprika/devrel/issues/169).
Same contract as
coinpaprika/dexpaprika-sdk-python#17, coinpaprika/dexpaprika-sdk-go#26 and
coinpaprika/dexpaprika-sdk-ts#82.

Based on `sdkv1.0.0`, which is this repo's default branch.

**Keyless stays the default and is untouched.**

### The key

```php
$config = (new Config())->setApiKey('api_your_key');
$client = new Client(null, null, false, $config);

$client = new Client();   // or DEXPAPRIKA_API_KEY
```

Precedence is explicit > environment > keyless. The key is the **entire**
`Authorization` value: no `Bearer`, no other scheme word, because the API
checksums the raw header and a scheme word returns 401. Tests assert against five
scheme words rather than trusting review.

Host is never inferred from the key: free keys stay on the default base URL, only
Pro moves via `setBaseUrl()`, and a free key sent to the Pro host returns 403.

A key carrying CR, LF or NUL is dropped rather than sanitised. A mangled key
authenticates as nobody, and because our data endpoints ignore an unreadable key
instead of rejecting it, the caller would never find out.

### Nothing to fix in the User-Agent here

Worth noting since the other three all had a problem with it: this SDK was
already sending `dexpaprika-sdk-php/` . `self::VERSION`. Python was pinned three
minor versions behind, TypeScript was pinned to 0.1.0 while shipping 1.9.0, and
Go carried no version at all. PHP got it right.

### Testing

12 new tests, 26 assertions. They assert on the headers that actually reach a
Guzzle mock handler rather than on stored values, and one case runs end to end
through the real `Client` constructor rather than a hand-built Guzzle client.

Covered: bare-key format vs five scheme words, keyless behaviour including blank
and whitespace-only values, precedence, whitespace trimming, header-injection
rejection, and the host rules in both directions.

Unit suite: **128 tests, 408 assertions**, all passing.